### PR TITLE
Append linter name to issue output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,20 @@ Run it:
 ```
 $ cd $GOPATH/src/github.com/alecthomas/gometalinter/example
 $ gometalinter
-stutter.go:22::error: Repeating defer a.Close() inside function duplicateDefer
-stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported
-stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported
-stutter.go:21:15:warning: error return value not checked (defer a.Close())
-stutter.go:22:15:warning: error return value not checked (defer a.Close())
-stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck)
-stutter.go:9::warning: unused global variable unusedGlobal
-stutter.go:13::warning: unused struct field MyStruct.Unused
-stutter.go:29::error: unreachable code
-stutter.go:26::error: missing argument for Printf("%d"): format reads arg 1, have only 0 args
+stutter.go:13::warning: unused struct field MyStruct.Unused (structcheck)
+stutter.go:9::warning: unused global variable unusedGlobal (varcheck)
+stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported (golint)
+stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (golint)
+stutter.go:22::error: Repeating defer a.Close() inside function duplicateDefer (defercheck)
+stutter.go:8:1:warning: unusedGlobal is unused (deadcode)
+stutter.go:12:1:warning: MyStruct is unused (deadcode)
+stutter.go:16:1:warning: PublicUndocumented is unused (deadcode)
+stutter.go:20:1:warning: duplicateDefer is unused (deadcode)
+stutter.go:21:15:warning: error return value not checked (defer a.Close()) (errcheck)
+stutter.go:22:15:warning: error return value not checked (defer a.Close()) (errcheck)
+stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck) (errcheck)
+stutter.go:29::error: unreachable code (vet)
+stutter.go:26::error: missing argument for Printf("%d"): format reads arg 1, have only 0 args (vet)
 ```
 
 ## Details
@@ -130,13 +134,13 @@ Additional linters can be configured via the command line:
 
 ```
 $ gometalinter --linter='vet:go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf {paths}:PATH:LINE:MESSAGE' .
-stutter.go:22::error: Repeating defer a.Close() inside function duplicateDefer
-stutter.go:21:15:warning: error return value not checked (defer a.Close())
-stutter.go:22:15:warning: error return value not checked (defer a.Close())
-stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck)
-stutter.go:9::warning: unused global variable unusedGlobal
-stutter.go:13::warning: unused struct field MyStruct.Unused
-stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported
-stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported
+stutter.go:22::error: Repeating defer a.Close() inside function duplicateDefer (defercheck)
+stutter.go:21:15:warning: error return value not checked (defer a.Close()) (errcheck)
+stutter.go:22:15:warning: error return value not checked (defer a.Close()) (errcheck)
+stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck) (errcheck)
+stutter.go:9::warning: unused global variable unusedGlobal (varcheck)
+stutter.go:13::warning: unused struct field MyStruct.Unused (structcheck)
+stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported (golint)
+stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (deadcode)
 ```
 

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func init() {
 }
 
 type Issue struct {
+	linter   Linter
 	severity Severity
 	path     string
 	line     int
@@ -129,7 +130,7 @@ func (m *Issue) String() string {
 	if m.col != 0 {
 		col = fmt.Sprintf("%d", m.col)
 	}
-	return fmt.Sprintf("%s:%d:%s:%s: %s", m.path, m.line, col, m.severity, m.message)
+	return fmt.Sprintf("%s:%d:%s:%s: %s (%s)", m.path, m.line, col, m.severity, m.message, m.linter)
 }
 
 func debug(format string, args ...interface{}) {
@@ -355,6 +356,7 @@ func executeLinter(issues chan *Issue, name, command, pattern, paths string, var
 			continue
 		}
 		issue := &Issue{}
+		issue.linter = Linter(name)
 		for i, name := range re.SubexpNames() {
 			part := string(groups[0][i])
 			if name != "" {


### PR DESCRIPTION
When running `gometalinter`, I found it hard to fix the issues reported without knowing which linter they came from. This appends the linter name to the end of each line wrapped in parens.

    example/stutter.go:9::warning: unused global variable unusedGlobal (varcheck)
    example/stutter.go:21:15:warning: error return value not checked (defer a.Close()) (errcheck)
    example/stutter.go:22:15:warning: error return value not checked (defer a.Close()) (errcheck)
    example/stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck) (errcheck)
    example/stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported (golint)
    example/stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (golint)
    example/stutter.go:22::error: Repeating defer a.Close() inside function duplicateDefer (defercheck)
    example/stutter.go:8:1:warning: unusedGlobal is unused (deadcode)
    example/stutter.go:12:1:warning: MyStruct is unused (deadcode)
    example/stutter.go:16:1:warning: PublicUndocumented is unused (deadcode)
    example/stutter.go:20:1:warning: duplicateDefer is unused (deadcode)
    example/stutter.go:13::warning: unused struct field MyStruct.Unused (structcheck)

Alternatively, if it won't break an existing error parser, it could go at the beginning of the line instead:

    varcheck:example/stutter.go:9::warning: unused global variable unusedGlobal