### PR TITLE
Replace go-nyet by go tool vet --shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ It is intended for use with editor/IDE integration.
 ## Supported linters
 
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
+- [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
 - [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
 - [gocyclo](https://github.com/alecthomas/gocyclo) - Computes the cyclomatic complexity of functions.
-- [go-nyet](https://github.com/barakmich/go-nyet) - Similar to `go vet` but also detects aliased variables.
 - [golint](https://github.com/golang/lint) - Google's (mostly stylistic) linter.
 - [defercheck](https://github.com/opennota/check) - Checks for duplicate defer calls.
 - [varcheck](https://github.com/opennota/check) - Find unused global variables and constants.
@@ -61,7 +61,6 @@ Installing ineffassign -> go get -u github.com/gordonklaus/ineffassign
 Installing errcheck -> go get -u github.com/alecthomas/errcheck
 Installing varcheck -> go get -u github.com/opennota/check/cmd/varcheck
 Installing structcheck -> go get -u github.com/opennota/check/cmd/structcheck
-Installing go-nyet -> go get -u github.com/barakmich/go-nyet
 Installing dupl -> go get -u github.com/mibk/dupl
 ```
 
@@ -175,11 +174,11 @@ Default linters:
   gocyclo (github.com/alecthomas/gocyclo)
       gocyclo -over {mincyclo} {path}
       :^(?P<cyclo>\d+)\s+\S+\s(?P<function>\S+)\s+(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)
-  go-nyet (github.com/barakmich/go-nyet)
-      go-nyet {path}
-      :PATH:LINE:COL:MESSAGE
   vet ()
       go vet {path}
+      :PATH:LINE:MESSAGE
+  vet --shadow ()
+      go vet --shadow {path}
       :PATH:LINE:MESSAGE
 
 Severity override map (default is "error"):
@@ -189,7 +188,6 @@ Severity override map (default is "error"):
   structcheck -> warning
   deadcode -> warning
   gocyclo -> warning
-  go-nyet -> warning
   errcheck -> warning
 
 Flags:

--- a/example/stutter.go
+++ b/example/stutter.go
@@ -38,3 +38,11 @@ func do() {
 	}
 	println(a)
 }
+
+func testVetShadow(mystructs []*MyStruct) *MyStruct {
+	var foo *MyStruct
+	for _, mystruct := range mystructs {
+		foo := mystruct
+	}
+	return foo
+}

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ var (
 	lintersFlag = map[string]string{
 		"golint":       "golint {path}:PATH:LINE:COL:MESSAGE",
 		"vet":          "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
-		"vet --shadow": "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
+		"vetshadow": "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
 		"gotype":       "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
 		"errcheck":     `errcheck {path}:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":     `varcheck {path}:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):\s*(?P<message>\w+)$`,

--- a/main.go
+++ b/main.go
@@ -92,20 +92,20 @@ var (
 		"PATH:LINE:MESSAGE":     `^(?P<path>[^\s][^:]+?\.go):(?P<line>\d+):\s*(?P<message>.*)$`,
 	}
 	lintersFlag = map[string]string{
-		"golint":      "golint {path}:PATH:LINE:COL:MESSAGE",
-		"vet":         "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
-		"gotype":      "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
-		"errcheck":    `errcheck {path}:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
-		"varcheck":    `varcheck {path}:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):\s*(?P<message>\w+)$`,
-		"structcheck": `structcheck {tests=-t} {path}:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):\s*(?P<message>[\w.]+)$`,
-		"defercheck":  "defercheck {path}:PATH:LINE:MESSAGE",
-		"deadcode":    `deadcode {path}:^deadcode: (?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
-		"gocyclo":     `gocyclo -over {mincyclo} {path}:^(?P<cyclo>\d+)\s+\S+\s(?P<function>\S+)\s+(?P<path>[^:]+):(?P<line>\d+):(\d+)$`,
-		"go-nyet":     `go-nyet {path}:PATH:LINE:COL:MESSAGE`,
-		"ineffassign": `ineffassign -n {path}:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\s+(?P<message>.*)$`,
-		"testify":     `go test:Location:\s+(?P<path>[^:]+):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)`,
-		"test":        `go test:^--- FAIL: .*$\s+(?P<path>[^:]+):(?P<line>\d+): (?P<message>.*)$`,
-		"dupl":        `dupl -plumbing -threshold {duplthreshold} {path}/*.go:^(?P<path>[^\s][^:]+?\.go):(?P<line>\d+)-\d+:\s*(?P<message>.*)$`,
+		"golint":       "golint {path}:PATH:LINE:COL:MESSAGE",
+		"vet":          "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
+		"vet --shadow": "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
+		"gotype":       "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
+		"errcheck":     `errcheck {path}:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
+		"varcheck":     `varcheck {path}:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):\s*(?P<message>\w+)$`,
+		"structcheck":  `structcheck {tests=-t} {path}:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):\s*(?P<message>[\w.]+)$`,
+		"defercheck":   "defercheck {path}:PATH:LINE:MESSAGE",
+		"deadcode":     `deadcode {path}:^deadcode: (?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
+		"gocyclo":      `gocyclo -over {mincyclo} {path}:^(?P<cyclo>\d+)\s+\S+\s(?P<function>\S+)\s+(?P<path>[^:]+):(?P<line>\d+):(\d+)$`,
+		"ineffassign":  `ineffassign -n {path}:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\s+(?P<message>.*)$`,
+		"testify":      `go test:Location:\s+(?P<path>[^:]+):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)`,
+		"test":         `go test:^--- FAIL: .*$\s+(?P<path>[^:]+):(?P<line>\d+): (?P<message>.*)$`,
+		"dupl":         `dupl -plumbing -threshold {duplthreshold} {path}/*.go:^(?P<path>[^\s][^:]+?\.go):(?P<line>\d+)-\d+:\s*(?P<message>.*)$`,
 	}
 	disabledLinters           = []string{"testify", "test"}
 	enabledLinters            = []string{}
@@ -123,7 +123,6 @@ var (
 		"structcheck": "warning",
 		"deadcode":    "warning",
 		"gocyclo":     "warning",
-		"go-nyet":     "warning",
 		"ineffassign": "warning",
 		"dupl":        "warning",
 	}
@@ -136,7 +135,6 @@ var (
 		"structcheck": "github.com/opennota/check/cmd/structcheck",
 		"deadcode":    "github.com/remyoudompheng/go-misc/deadcode",
 		"gocyclo":     "github.com/alecthomas/gocyclo",
-		"go-nyet":     "github.com/barakmich/go-nyet",
 		"ineffassign": "github.com/gordonklaus/ineffassign",
 		"dupl":        "github.com/mibk/dupl",
 	}


### PR DESCRIPTION
- Implementation of `go tool vet --shadow` for reporting shadowed variables
- Remove the [deprecated](https://github.com/barakmich/go-nyet#deprecated) `go-nyet`
- Update the `README`

Fixes #28.