### PR TITLE
Implement goimports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is intended for use with editor/IDE integration.
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
 - [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
+- [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) - Checks missing or unreferenced package imports.
 - [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
 - [gocyclo](https://github.com/alecthomas/gocyclo) - Computes the cyclomatic complexity of functions.
 - [golint](https://github.com/golang/lint) - Google's (mostly stylistic) linter.
@@ -63,6 +64,7 @@ Installing ineffassign -> go get github.com/gordonklaus/ineffassign
 Installing dupl -> go get github.com/mibk/dupl
 Installing golint -> go get github.com/golang/lint/golint
 Installing gotype -> go get golang.org/x/tools/cmd/gotype
+Installing goimports -> go get golang.org/x/tools/cmd/goimports
 Installing errcheck -> go get github.com/alecthomas/errcheck
 Installing defercheck -> go get github.com/opennota/check/cmd/defercheck
 Installing varcheck -> go get github.com/opennota/check/cmd/varcheck

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Default linters:
   gotype (golang.org/x/tools/cmd/gotype)
       gotype {tests=-a} {path}
       :PATH:LINE:COL:MESSAGE
+  goimports (golang.org/x/tools/cmd/goimports)
+      goimports -d {path}
+      :^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)
   varcheck (github.com/opennota/check/cmd/varcheck)
       varcheck {path}
       :^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ var (
 		"vet":         "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
 		"vetshadow":   "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
 		"gotype":      "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
+		"goimports":   `goimports -d {path}:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+),`,
 		"errcheck":    `cd {path} && errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `cd {path} && varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `cd {path} && structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
@@ -116,6 +117,7 @@ var (
 		"varcheck":    "unused global variable {message}",
 		"structcheck": "unused struct field {message}",
 		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
+		"goimports":   "file is not goimported",
 	}
 	linterSeverityFlag = map[string]string{
 		"errcheck":    "warning",
@@ -131,6 +133,7 @@ var (
 	installMap = map[string]string{
 		"golint":      "github.com/golang/lint/golint",
 		"gotype":      "golang.org/x/tools/cmd/gotype",
+		"goimports":   "golang.org/x/tools/cmd/goimports",
 		"errcheck":    "github.com/alecthomas/errcheck",
 		"defercheck":  "github.com/opennota/check/cmd/defercheck",
 		"varcheck":    "github.com/opennota/check/cmd/varcheck",

--- a/main.go
+++ b/main.go
@@ -103,10 +103,10 @@ var (
 	}
 	lintersFlag = map[string]string{
 		"golint":      "golint -min_confidence {min_confidence} .:PATH:LINE:COL:MESSAGE",
-		"vet":         "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
-		"vetshadow":   "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
-		"gotype":      "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
-		"goimports":   `goimports -d {path}:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+),`,
+		"vet":         "go tool vet ./*.go:PATH:LINE:MESSAGE",
+		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
+		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
+		"goimports":   `goimports -d .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,

--- a/regression_tests/goimports_test.go
+++ b/regression_tests/goimports_test.go
@@ -1,0 +1,14 @@
+package regression_tests
+
+import "testing"
+
+func TestGoimports(t *testing.T) {
+	source := `
+package test
+func test() {fmt.Println(nil)}
+`
+	expected := Issues{
+		{Linter: "goimports", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "file is not goimported"},
+	}
+	ExpectIssues(t, "goimports", source, expected)
+}


### PR DESCRIPTION
`goimport` output is overridden by a simple message: `file is not goimported`.
A possible evolution would be to report precisely which imports are missing or not used.

Fixes #38.