### PR TITLE
Implement gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It is intended for use with editor/IDE integration.
 
 ## Supported linters
 
+- [gofmt -s](https://golang.org/cmd/gofmt/) - Checks if the code is properly formatted and could not be further simplified.
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
 - [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
@@ -188,6 +189,9 @@ Default linters:
   vet --shadow ()
       go vet --shadow {path}
       :PATH:LINE:MESSAGE
+  gofmt ()
+      gofmt -s -d -e {path}
+      :^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`
 
 Severity override map (default is "error"):
 

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ var (
 		"golint":      "golint -min_confidence {min_confidence} .:PATH:LINE:COL:MESSAGE",
 		"vet":         "go tool vet ./*.go:PATH:LINE:MESSAGE",
 		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
+		"gofmt":       `gofmt -s -d -e .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
@@ -125,6 +126,7 @@ var (
 		"varcheck":    "unused global variable {message}",
 		"structcheck": "unused struct field {message}",
 		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
+		"gofmt":       "file is not gofmted",
 	}
 	linterSeverityFlag = map[string]string{
 		"errcheck":    "warning",

--- a/regression_tests/gofmt_test.go
+++ b/regression_tests/gofmt_test.go
@@ -1,0 +1,14 @@
+package regression_tests
+
+import "testing"
+
+func TestGofmt(t *testing.T) {
+	source := `
+package test
+func test() { if nil {} }
+`
+	expected := Issues{
+		{Linter: "gofmt", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "file is not gofmted"},
+	}
+	ExpectIssues(t, "gofmt", source, expected)
+}


### PR DESCRIPTION
Right now it reports with a very simple message as suggested: `file is not gofmted`.
It might be interesting in the future to report the lines impacted (maybe with a generic flag `-v`?).

Fixes #37.