### PR TITLE
Implement goimports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is intended for use with editor/IDE integration.
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
 - [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
+- [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) - Checks missing or unreferenced package imports.
 - [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
 - [gocyclo](https://github.com/alecthomas/gocyclo) - Computes the cyclomatic complexity of functions.
 - [golint](https://github.com/golang/lint) - Google's (mostly stylistic) linter.
@@ -63,6 +64,7 @@ Installing ineffassign -> go get github.com/gordonklaus/ineffassign
 Installing dupl -> go get github.com/mibk/dupl
 Installing golint -> go get github.com/golang/lint/golint
 Installing gotype -> go get golang.org/x/tools/cmd/gotype
+Installing goimports -> go get golang.org/x/tools/cmd/goimports
 Installing errcheck -> go get github.com/alecthomas/errcheck
 Installing defercheck -> go get github.com/opennota/check/cmd/defercheck
 Installing varcheck -> go get github.com/opennota/check/cmd/varcheck

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Default linters:
   gotype (golang.org/x/tools/cmd/gotype)
       gotype {tests=-a} {path}
       :PATH:LINE:COL:MESSAGE
+  goimports (golang.org/x/tools/cmd/goimports)
+      goimports -d {path}
+      :^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)
   varcheck (github.com/opennota/check/cmd/varcheck)
       varcheck {path}
       :^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Default linters:
       :PATH:LINE:COL:MESSAGE
   goimports (golang.org/x/tools/cmd/goimports)
       goimports -d {path}
-      :^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)
+      :^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)[\S\s]+import
   varcheck (github.com/opennota/check/cmd/varcheck)
       varcheck {path}
       :^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$

--- a/main.go
+++ b/main.go
@@ -100,15 +100,14 @@ var (
 	predefinedPatterns = map[string]string{
 		"PATH:LINE:COL:MESSAGE": `^(?P<path>[^\s][^:]+?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
 		"PATH:LINE:MESSAGE":     `^(?P<path>[^\s][^:]+?\.go):(?P<line>\d+):\s*(?P<message>.*)$`,
-		"DIFF:PATH:LINE":        `^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 	}
 	lintersFlag = map[string]string{
 		"golint":      "golint -min_confidence {min_confidence} .:PATH:LINE:COL:MESSAGE",
 		"vet":         "go tool vet ./*.go:PATH:LINE:MESSAGE",
 		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
-		"gofmt":       `gofmt -s -d -e .:DIFF:PATH:LINE`,
+		"gofmt":       `gofmt -s -d -e .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
-		"goimports":   `goimports -d .:DIFF:PATH:LINE`,
+		"goimports":   `goimports -d .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)[\S\s]+import`,
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ var (
 		"vet":         "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
 		"vetshadow":   "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
 		"gotype":      "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
+		"goimports":   `goimports -d {path}:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+),`,
 		"errcheck":    `cd {path} && errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `cd {path} && varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `cd {path} && structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
@@ -116,6 +117,7 @@ var (
 		"varcheck":    "unused global variable {message}",
 		"structcheck": "unused struct field {message}",
 		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
+		"goimports":   "file is not goimported",
 	}
 	linterSeverityFlag = map[string]string{
 		"errcheck":    "warning",
@@ -131,6 +133,7 @@ var (
 	installMap = map[string]string{
 		"golint":      "github.com/golang/lint/golint",
 		"gotype":      "golang.org/x/tools/cmd/gotype",
+		"goimports":   "golang.org/x/tools/cmd/goimports",
 		"errcheck":    "github.com/alecthomas/errcheck",
 		"defercheck":  "github.com/opennota/check/cmd/defercheck",
 		"varcheck":    "github.com/opennota/check/cmd/varcheck",

--- a/main.go
+++ b/main.go
@@ -103,10 +103,10 @@ var (
 	}
 	lintersFlag = map[string]string{
 		"golint":      "golint -min_confidence {min_confidence} .:PATH:LINE:COL:MESSAGE",
-		"vet":         "go tool vet {path}/*.go:PATH:LINE:MESSAGE",
-		"vetshadow":   "go tool vet --shadow {path}/*.go:PATH:LINE:MESSAGE",
-		"gotype":      "gotype -e {tests=-a} {path}:PATH:LINE:COL:MESSAGE",
-		"goimports":   `goimports -d {path}:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+),`,
+		"vet":         "go tool vet ./*.go:PATH:LINE:MESSAGE",
+		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
+		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
+		"goimports":   `goimports -d .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ var (
 		"structcheck": "unused struct field {message}",
 		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
 		"gofmt":       "file is not gofmted",
-		"goimports":   "file is not goimported",
+		"goimports":   "missing or unreferenced package imports",
 	}
 	linterSeverityFlag = map[string]string{
 		"errcheck":    "warning",

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ var (
 		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
 		"gofmt":       `gofmt -s -d -e .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)`,
 		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
-		"goimports":   `goimports -d .:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)[\S\s]+import`,
+		"goimports":   `goimports -d ./*.go:^diff\s(?P<path>\S+)\s.+\s.+\s.+\s@@\s-(?P<line>\d+)[\S\s]+import`,
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,

--- a/regression_tests/goimports_test.go
+++ b/regression_tests/goimports_test.go
@@ -1,0 +1,14 @@
+package regression_tests
+
+import "testing"
+
+func TestGoimports(t *testing.T) {
+	source := `
+package test
+func test() {fmt.Println(nil)}
+`
+	expected := Issues{
+		{Linter: "goimports", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "file is not goimported"},
+	}
+	ExpectIssues(t, "goimports", source, expected)
+}

--- a/regression_tests/goimports_test.go
+++ b/regression_tests/goimports_test.go
@@ -8,7 +8,7 @@ package test
 func test() {fmt.Println(nil)}
 `
 	expected := Issues{
-		{Linter: "goimports", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "file is not goimported"},
+		{Linter: "goimports", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "missing or unreferenced package imports"},
 	}
 	ExpectIssues(t, "goimports", source, expected)
 }


### PR DESCRIPTION
goimport output is overridden with a simple message: `missing or unreferenced package imports`.
:warning: `goimports` only reports on `import` changes, since `gofmt` is already checking the formatting.
 
A possible evolution would be to report precisely which imports are unreferenced or not used.

Fixes #38.