### PR TITLE
Implement goimports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It is intended for use with editor/IDE integration.
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
 - [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
+- [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) - Checks missing or unreferenced package imports.
 - [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
 - [gocyclo](https://github.com/alecthomas/gocyclo) - Computes the cyclomatic complexity of functions.
 - [golint](https://github.com/golang/lint) - Google's (mostly stylistic) linter.
@@ -64,6 +65,7 @@ Installing ineffassign -> go get github.com/gordonklaus/ineffassign
 Installing dupl -> go get github.com/mibk/dupl
 Installing golint -> go get github.com/golang/lint/golint
 Installing gotype -> go get golang.org/x/tools/cmd/gotype
+Installing goimports -> go get golang.org/x/tools/cmd/goimports
 Installing errcheck -> go get github.com/kisielk/errcheck
 Installing defercheck -> go get github.com/opennota/check/cmd/defercheck
 Installing varcheck -> go get github.com/opennota/check/cmd/varcheck
@@ -159,6 +161,9 @@ gofmt
 gotype  (golang.org/x/tools/cmd/gotype)
       gotype -e {tests=-a} .
       :PATH:LINE:COL:MESSAGE
+goimports (golang.org/x/tools/cmd/goimports)
+      goimports -l ./*.go
+      :^(?P<path>[^\n]+)$
 testify
       go test
       :Location:\s+(?P<path>[^:]+):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ var (
 		"vetshadow":   "go tool vet --shadow ./*.go:PATH:LINE:MESSAGE",
 		"gofmt":       `gofmt -l -s ./*.go:^(?P<path>[^\n]+)$`,
 		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
+		"goimports":   `goimports -l ./*.go:^(?P<path>[^\n]+)$`,
 		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
@@ -127,6 +128,7 @@ var (
 		"structcheck": "unused struct field {message}",
 		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
 		"gofmt":       "file is not gofmted",
+		"goimports":   "file is not goimported",
 	}
 	linterSeverityFlag = map[string]string{
 		"errcheck":    "warning",
@@ -142,6 +144,7 @@ var (
 	installMap = map[string]string{
 		"golint":      "github.com/golang/lint/golint",
 		"gotype":      "golang.org/x/tools/cmd/gotype",
+		"goimports":   "golang.org/x/tools/cmd/goimports",
 		"errcheck":    "github.com/kisielk/errcheck",
 		"defercheck":  "github.com/opennota/check/cmd/defercheck",
 		"varcheck":    "github.com/opennota/check/cmd/varcheck",

--- a/regression_tests/goimports_test.go
+++ b/regression_tests/goimports_test.go
@@ -1,0 +1,14 @@
+package regression_tests
+
+import "testing"
+
+func TestGoimports(t *testing.T) {
+	source := `
+package test
+func test() {fmt.Println(nil)}
+`
+	expected := Issues{
+		{Linter: "goimports", Severity: "error", Path: "test.go", Line: 1, Col: 0, Message: "file is not goimported"},
+	}
+	ExpectIssues(t, "goimports", source, expected)
+}


### PR DESCRIPTION
`goimport`'s output is overridden with a simple message: `file is not goimported`.

Fixes #38.