### PR TITLE
Pass `-abspath` to errcheck to avoid broken paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ var (
 		"gofmt":       `gofmt -l -s ./*.go:^(?P<path>[^\n]+)$`,
 		"gotype":      "gotype -e {tests=-a} .:PATH:LINE:COL:MESSAGE",
 		"goimports":   `goimports -l ./*.go:^(?P<path>[^\n]+)$`,
-		"errcheck":    `errcheck .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
+		"errcheck":    `errcheck -abspath .:^(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+)\t(?P<message>.*)$`,
 		"varcheck":    `varcheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$`,
 		"structcheck": `structcheck {tests=-t} .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
 		"defercheck":  `defercheck .:^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,


### PR DESCRIPTION
Fixes #53