### PR TITLE
Change logging to avoid confusing installation errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -498,7 +498,9 @@ func doInstall() {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	err := c.Run()
-	kingpin.CommandLine.FatalIfError(err, "failed to install %s: %s", namesStr, err)
+	if err != nil {
+		warning("Linter(s) not installed")
+	}
 }
 
 func maybeSortIssues(issues chan *Issue) chan *Issue {


### PR DESCRIPTION
Avoids confusing errors which appear to refer to the wrong linter
e.g. `gometalinter: error: failed to install ineffassign` which was in the output of issue #62 

No need to print error in the warning, as any errors have already been printed.