### PR TITLE
Use standalone repo of deadcode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Installing:
   go get -u github.com/alecthomas/gometalinter \
     github.com/opennota/check/cmd/structcheck \
     github.com/opennota/check/cmd/aligncheck \
-    github.com/remyoudompheng/go-misc/deadcode \
+    github.com/tsenart/deadcode \
     github.com/alecthomas/gocyclo \
     github.com/gordonklaus/ineffassign \
     github.com/mibk/dupl \
@@ -231,7 +231,7 @@ vetshadow
 varcheck  (github.com/opennota/check/cmd/varcheck)
       varcheck .
       :^(?:[^:]+: )?(?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>\w+)$
-deadcode  (github.com/remyoudompheng/go-misc/deadcode)
+deadcode  (github.com/tsenart/deadcode)
       deadcode .
       :^deadcode: (?P<path>[^:]+):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$
 interfacer  (github.com/mvdan/interfacer/cmd/interfacer)

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ var (
 		"varcheck":     "github.com/opennota/check/cmd/varcheck",
 		"structcheck":  "github.com/opennota/check/cmd/structcheck",
 		"aligncheck":   "github.com/opennota/check/cmd/aligncheck",
-		"deadcode":     "github.com/remyoudompheng/go-misc/deadcode",
+		"deadcode":     "github.com/tsenart/deadcode",
 		"gocyclo":      "github.com/alecthomas/gocyclo",
 		"ineffassign":  "github.com/gordonklaus/ineffassign",
 		"dupl":         "github.com/mibk/dupl",


### PR DESCRIPTION
This commit alters the origin of the deadcode package to a standalone
version which doesn't contain all the other unrelated code that's
present in upstream.

This is important when vendoring the many tools for reproducible builds.