### PR TITLE
Only Print A Comma When There's An Issue To Print

### DIFF
--- a/main.go
+++ b/main.go
@@ -358,11 +358,11 @@ func outputToJSON(issues chan *Issue) int {
 	fmt.Println("[")
 	status := 0
 	for issue := range issues {
-		if status != 0 {
-			fmt.Printf(",\n")
-		}
 		if *errorsFlag && issue.Severity != Error {
 			continue
+		}
+		if status != 0 {
+			fmt.Printf(",\n")
 		}
 		d, err := json.Marshal(issue)
 		kingpin.FatalIfError(err, "")


### PR DESCRIPTION
This PR moves the logic used to print a comma below the logic used to skip warnings when `errorsFlag` is used. Without this change, extraneous commas are printed in the JSON output, causing JSON parsing to fail.

Fixes #101 