### PR TITLE
Issue alecthomas/gometalinter#118 - add client9/misspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Disabled by default (enable with `--enable=<linter>`):
 - [gofmt -s](https://golang.org/cmd/gofmt/) - Checks if the code is properly formatted and could not be further simplified.
 - [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) - Checks missing or unreferenced package imports.
 - [lll](https://github.com/walle/lll) - Report long lines (see `--line-length=N`).
+- [misspell](https://github.com/client9/misspell) - Finds commonly misspelled English words.
 
 Additional linters can be added through the command line with `--linter=NAME:COMMAND:PATTERN` (see [below](#details)).
 

--- a/main.go
+++ b/main.go
@@ -136,8 +136,9 @@ var (
 		"unconvert":   "unconvert .:PATH:LINE:COL:MESSAGE",
 		"gosimple":    "gosimple .:PATH:LINE:COL:MESSAGE",
 		"staticcheck": "staticcheck .:PATH:LINE:COL:MESSAGE",
+		"misspell":    "misspell ./*.go:PATH:LINE:COL:MESSAGE",
 	}
-	disabledLinters           = []string{"testify", "test", "gofmt", "goimports", "lll"}
+	disabledLinters           = []string{"testify", "test", "gofmt", "goimports", "lll", "misspell"}
 	enabledLinters            = []string{}
 	linterMessageOverrideFlag = map[string]string{
 		"errcheck":    "error return value not checked ({message})",
@@ -163,6 +164,7 @@ var (
 		"aligncheck":  "github.com/opennota/check/cmd/aligncheck",
 		"deadcode":    "github.com/tsenart/deadcode",
 		"gocyclo":     "github.com/alecthomas/gocyclo",
+		"misspell":    "github.com/client9/misspell/cmd/misspell",
 		"ineffassign": "github.com/gordonklaus/ineffassign",
 		"dupl":        "github.com/mibk/dupl",
 		"interfacer":  "github.com/mvdan/interfacer/cmd/interfacer",


### PR DESCRIPTION

This adds https://github.com/client9/misspell  Since it applies to English (which is not required by golang) and possibility of false positives,  it is disabled by default.  This matches gofmt and lll.  But happy to make it on-by-default.

To test,

first remove misspell if it exists
```
rm `which misspell`
```

test install

```bash
go run main.go --install --update
which misspell
```


test lint by making `junk.go` that contains something like `// TOOD: write code`

```
go run main.go -enable misspell .
```

You should get something like this:

```
junk.go:3:3:warning: found "TOOD:" a misspelling of "TODO:" (misspell)
```

onward!

n
