### PR TITLE
Change {paths} to {path} in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Args:
 Additional linters can be configured via the command line:
 
 ```
-$ gometalinter --linter='vet:go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf {paths}:PATH:LINE:MESSAGE' .
+$ gometalinter --linter='vet:go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf {path}:PATH:LINE:MESSAGE' .
 stutter.go:21:15:warning: error return value not checked (defer a.Close()) (errcheck)
 stutter.go:22:15:warning: error return value not checked (defer a.Close()) (errcheck)
 stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck) (errcheck)


### PR DESCRIPTION
I assume this is a typo in the README. A basic test shows that `{path}` is the correct keyword, whereas `{paths}` doesn't do anything special. I tested this via the following command:

    gometalinter --vendor --disable-all --linter='vet:bash -c "echo {path} >~/Desktop/proof":PATH:LINE:MESSAGE' --enable=vet .

The above command writes the  `.` (or whatever path you choose to pass to the linter) to the file. Replacing `{path}` with `{paths}` causes "{paths}" to be written to the file, which is clearly not what we want.