### PR TITLE
Add link to fork of deadcode which is really used

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is intended for use with editor/IDE integration.
 - [go vet](https://golang.org/cmd/vet/) - Reports potential errors that otherwise compile.
 - [go vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [gotype](https://golang.org/x/tools/cmd/gotype) - Syntactic and semantic analysis similar to the Go compiler.
-- [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
+- [deadcode](https://github.com/tsenart/deadcode) - Finds unused code.
 - [gocyclo](https://github.com/alecthomas/gocyclo) - Computes the cyclomatic complexity of functions.
 - [golint](https://github.com/golang/lint) - Google's (mostly stylistic) linter.
 - [varcheck](https://github.com/opennota/check) - Find unused global variables and constants.


### PR DESCRIPTION
There is bug which was fixed in parent project, but not in fork and it took too much time for me to understand why it is not working on my machine