### PR TITLE
Add support for checkstyle output mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: go
 install:
     - go get -t -v . ./regressiontests
-    - go run main.go --install
+    - gometalinter --install
 go: 1.7
 script: go test -v . ./regressiontests

--- a/README.md
+++ b/README.md
@@ -214,3 +214,18 @@ stutter.go:13::warning: unused struct field MyStruct.Unused (structcheck)
 stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported (golint)
 stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (deadcode)
 ```
+
+## Different output modes
+
+`gometalinter` supports three types of different output modes:
+
+* `console` - default plain-text output mode.
+* `json` - structured JSON output mode, useful for integration with other tools.
+* `checkstyle` - XML encoded output compatible with
+  [checkstyle](http://checkstyle.sourceforge.net/) tool. Useful for integration
+  with tools that already support checkstyle documents (for example JENKINS
+  [Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin)).
+
+Output mode can be changed with `--output=console|json|checkstyle` flag. Flag 
+`--json` is left for backwards compatibility and is identical to
+`--output=json`.

--- a/README.md
+++ b/README.md
@@ -215,17 +215,12 @@ stutter.go:12:6:warning: exported type MyStruct should have comment or be unexpo
 stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (deadcode)
 ```
 
-## Different output modes
+## Checkstyle XML format
 
-`gometalinter` supports three types of different output modes:
+`gometalinter` supports [checkstyle](http://checkstyle.sourceforge.net/)
+compatible XML output format. It is tiggered with `--checkstyle` flag:
 
-* `console` - default plain-text output mode.
-* `json` - structured JSON output mode, useful for integration with other tools.
-* `checkstyle` - XML encoded output compatible with
-  [checkstyle](http://checkstyle.sourceforge.net/) tool. Useful for integration
-  with tools that already support checkstyle documents (for example JENKINS
-  [Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin)).
+	gometalinter --checkstyle
 
-Output mode can be changed with `--output=console|json|checkstyle` flag. Flag 
-`--json` is left for backwards compatibility and is identical to
-`--output=json`.
+Checkstyle format can be used to integrate gometalinter with Jenkins CI with the
+help of [Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin)).

--- a/README.md
+++ b/README.md
@@ -223,4 +223,4 @@ compatible XML output format. It is tiggered with `--checkstyle` flag:
 	gometalinter --checkstyle
 
 Checkstyle format can be used to integrate gometalinter with Jenkins CI with the
-help of [Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin)).
+help of [Checkstyle Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin).

--- a/checkstyle.go
+++ b/checkstyle.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+type checkstyleOutput struct {
+	XMLName xml.Name          `xml:"checkstyle"`
+	Version string            `xml:"version,attr"`
+	Files   []*checkstyleFile `xml:"file"`
+}
+
+type checkstyleFile struct {
+	Name   string             `xml:"name,attr"`
+	Errors []*checkstyleError `xml:"error"`
+}
+
+type checkstyleError struct {
+	Column   int    `xml:"column,attr"`
+	Line     int    `xml:"line,attr"`
+	Message  string `xml:"message,attr"`
+	Severity string `xml:"severity,attr"`
+	Source   string `xml:"source,attr"`
+}
+
+func outputToCheckstyle(issues chan *Issue) int {
+	var lastFile *checkstyleFile
+	out := checkstyleOutput{
+		Version: "5.0",
+	}
+	status := 0
+	for issue := range issues {
+		if lastFile != nil && lastFile.Name != issue.Path {
+			out.Files = append(out.Files, lastFile)
+			lastFile = nil
+		}
+		if lastFile == nil {
+			lastFile = &checkstyleFile{
+				Name: issue.Path,
+			}
+		}
+		lastFile.Errors = append(lastFile.Errors, &checkstyleError{
+			Column:   issue.Col,
+			Line:     issue.Line,
+			Message:  issue.Message,
+			Severity: string(issue.Severity),
+			Source:   issue.Linter.Name,
+		})
+		status = 1
+	}
+	if lastFile != nil {
+		out.Files = append(out.Files, lastFile)
+	}
+	fmt.Println(`<?xml version="1.0" encoding="UTF-8"?>`)
+	d, err := xml.Marshal(&out)
+	kingpin.FatalIfError(err, "")
+	fmt.Printf("%s\n", d)
+	return status
+}

--- a/checkstyle.go
+++ b/checkstyle.go
@@ -54,9 +54,8 @@ func outputToCheckstyle(issues chan *Issue) int {
 	if lastFile != nil {
 		out.Files = append(out.Files, lastFile)
 	}
-	fmt.Println(`<?xml version="1.0" encoding="UTF-8"?>`)
 	d, err := xml.Marshal(&out)
 	kingpin.FatalIfError(err, "")
-	fmt.Printf("%s\n", d)
+	fmt.Printf("%s%s\n", xml.Header, d)
 	return status
 }

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ var (
 	errorsFlag          = kingpin.Flag("errors", "Only show errors.").Bool()
 	jsonFlag            = kingpin.Flag("json", "Generate structured JSON rather than standard line-based output.").Bool()
 	enableGCFlag        = kingpin.Flag("enable-gc", "Enable GC for linters (useful on large repositories).").Bool()
-	outputFlag          = kingpin.Flag("output", fmt.Sprintf("Output format, one of %s", strings.Join(outputKeys, ", "))).Default("console").Enum(outputKeys...)
+	outputFlag          = kingpin.Flag("output", fmt.Sprintf("Output format, one of %s.", strings.Join(outputKeys, ", "))).Default("console").Enum(outputKeys...)
 )
 
 func disableAllLinters(*kingpin.ParseContext) error {

--- a/regressiontests/support.go
+++ b/regressiontests/support.go
@@ -58,7 +58,7 @@ func ExpectIssues(t *testing.T, linter string, source string, expected Issues, e
 	}
 
 	// Run gometalinter.
-	args := []string{"go", "run", "../main.go", "--disable-all", "--enable", linter, "--json", dir}
+	args := []string{"go", "run", "../main.go", "../checkstyle.go", "--disable-all", "--enable", linter, "--json", dir}
 	args = append(args, extraFlags...)
 	cmd := exec.Command(args[0], args[1:]...)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Checkstyle is a static code quality analysis tool widely used in Java community. This pull request adds a flag to produce output in checkstyle XML format. New output format is enabled with --output=checkstyle argument, which can be easily extended to support even more output types if the need arises.

Checkstyle format has almost identical structure as JSON that gometalinter already produces. the only difference is mandatory grouping of errors by file name and XML encoding.

Main use-case of this would be gometalinter output integration with Jenkins CI system. Jenkins has a good support for checkstyle output via https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin plugin. It adds static code analysis trend graph and allows browsing detected issues from web interface.