### PR TITLE
Aggregate lines

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sort"
+	"strings"
+)
+
+type (
+	issueKey struct {
+		path      string
+		line, col int
+		message   string
+	}
+
+	multiIssue struct {
+		*Issue
+		linterNames []string
+	}
+)
+
+func aggregateIssues(issues chan *Issue) chan *Issue {
+	out := make(chan *Issue, 1000000)
+	issueMap := make(map[issueKey]*multiIssue)
+	go func() {
+		for issue := range issues {
+			key := issueKey{
+				path:    issue.Path,
+				line:    issue.Line,
+				col:     issue.Col,
+				message: issue.Message,
+			}
+			if existing, ok := issueMap[key]; ok {
+				existing.linterNames = append(existing.linterNames, issue.Linter.Name)
+			} else {
+				issueMap[key] = &multiIssue{
+					Issue:       issue,
+					linterNames: []string{issue.Linter.Name},
+				}
+			}
+		}
+		for _, multi := range issueMap {
+			issue := multi.Issue
+			sort.Strings(multi.linterNames)
+			issue.Linter.Name = strings.Join(multi.linterNames, ", ")
+			out <- issue
+		}
+		close(out)
+	}()
+	return out
+}

--- a/main.go
+++ b/main.go
@@ -223,6 +223,7 @@ var (
 	jsonFlag            = kingpin.Flag("json", "Generate structured JSON rather than standard line-based output.").Bool()
 	checkstyleFlag      = kingpin.Flag("checkstyle", "Generate checkstyle XML rather than standard line-based output.").Bool()
 	enableGCFlag        = kingpin.Flag("enable-gc", "Enable GC for linters (useful on large repositories).").Bool()
+	aggregateFlag       = kingpin.Flag("aggregate", "Aggregate issues reported by several linters.").Bool()
 )
 
 func disableAllLinters(*kingpin.ParseContext) error {
@@ -434,7 +435,7 @@ func runLinters(linters map[string]*Linter, paths, ellipsisPaths []string, concu
 	errch := make(chan error, len(linters)*(len(paths)+len(ellipsisPaths)))
 	concurrencych := make(chan bool, *concurrencyFlag)
 	incomingIssues := make(chan *Issue, 1000000)
-	processedIssues := maybeSortIssues(incomingIssues)
+	processedIssues := maybeSortIssues(maybeAggregateIssues(incomingIssues))
 	wg := &sync.WaitGroup{}
 	for _, linter := range linters {
 		// Recreated in each loop because it is mutated by executeLinter().
@@ -591,6 +592,13 @@ func installLinters() {
 	}
 	warning("failed to install one or more linters: %s (installing individually)", err)
 	installLintersIndividually(targets)
+}
+
+func maybeAggregateIssues(issues chan *Issue) chan *Issue {
+	if !*aggregateFlag {
+		return issues
+	}
+	return aggregateIssues(issues)
 }
 
 func maybeSortIssues(issues chan *Issue) chan *Issue {

--- a/regressiontests/structcheck_test.go
+++ b/regressiontests/structcheck_test.go
@@ -1,6 +1,11 @@
 package regressiontests
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+type Empty struct{}
 
 func TestStructcheck(t *testing.T) {
 	t.Parallel()
@@ -10,8 +15,9 @@ type test struct {
 	unused int
 }
 `
+	pkgName := reflect.TypeOf(Empty{}).PkgPath()
 	expected := Issues{
-		{Linter: "structcheck", Severity: "warning", Path: "test.go", Line: 4, Col: 2, Message: "unused struct field github.com/alecthomas/gometalinter/regressiontests/.test.unused"},
+		{Linter: "structcheck", Severity: "warning", Path: "test.go", Line: 4, Col: 2, Message: "unused struct field " + pkgName + "/.test.unused"},
 	}
 	ExpectIssues(t, "structcheck", source, expected)
 }

--- a/regressiontests/structcheck_test.go
+++ b/regressiontests/structcheck_test.go
@@ -1,11 +1,6 @@
 package regressiontests
 
-import (
-	"reflect"
-	"testing"
-)
-
-type Empty struct{}
+import "testing"
 
 func TestStructcheck(t *testing.T) {
 	t.Parallel()
@@ -15,9 +10,8 @@ type test struct {
 	unused int
 }
 `
-	pkgName := reflect.TypeOf(Empty{}).PkgPath()
 	expected := Issues{
-		{Linter: "structcheck", Severity: "warning", Path: "test.go", Line: 4, Col: 2, Message: "unused struct field " + pkgName + "/.test.unused"},
+		{Linter: "structcheck", Severity: "warning", Path: "test.go", Line: 4, Col: 2, Message: "unused struct field github.com/alecthomas/gometalinter/regressiontests/.test.unused"},
 	}
 	ExpectIssues(t, "structcheck", source, expected)
 }

--- a/regressiontests/support.go
+++ b/regressiontests/support.go
@@ -58,7 +58,7 @@ func ExpectIssues(t *testing.T, linter string, source string, expected Issues, e
 	}
 
 	// Run gometalinter.
-	args := []string{"go", "run", "../main.go", "../checkstyle.go", "--disable-all", "--enable", linter, "--json", dir}
+	args := []string{"go", "run", "../main.go", "../checkstyle.go", "../aggregate.go", "--disable-all", "--enable", linter, "--json", dir}
 	args = append(args, extraFlags...)
 	cmd := exec.Command(args[0], args[1:]...)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Hi, this PR adds an option that aggregate duplicate messages of the same issue (reported by several linters), it intends to fix #117. Like `--sort`, `--aggregate` can't stream the issues and is an opt-in. It is also compatible with `--sort`.
Two issues are considered equals if the same message is reported for the same location. See examples below.

```
% ls
test.go
% cat test.go
package main

func main() {
    println(("hey")
}
% gometalinter --sort line
test.go:4:20:warning: error return value not checked (missing ',' before newline in argument list (and 1 more errors)) (errcheck)
test.go:4:20:warning: unused global variable missing ',' before newline in argument list (and 1 more errors) (varcheck)
test.go:4:20:error: missing ',' before newline in argument list (gotype)
vet: test.go: test.go:4::error: 20: missing ',' before newline in argument list (and 1 more errors) (vet)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (interfacer)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (unconvert)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (aligncheck)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (deadcode)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (gosimple)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (staticcheck)
test.go:4:20:warning: unused struct field missing ',' before newline in argument list (and 1 more errors) (structcheck)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (golint)
vet: test.go: test.go:4::warning: 20: missing ',' before newline in argument list (and 1 more errors) (vetshadow)
test.go:5:3:error: expected '}', found 'EOF' (gotype)
test.go:5:3:error: expected ';', found 'EOF' (gotype)
test.go:5:3:error: expected ';', found 'EOF' (gotype)
test.go:5:3:error: expected ')', found 'EOF' (gotype)
test.go:5:1:error: expected operand, found '}' (gotype)
test.go:5:3:error: missing ',' in argument list (gotype)
% gometalinter --aggregate --sort line
test.go:4:20:warning: unused struct field missing ',' before newline in argument list (and 1 more errors) (structcheck)
test.go:4:20:warning: error return value not checked (missing ',' before newline in argument list (and 1 more errors)) (errcheck)
test.go:4:20:warning: missing ',' before newline in argument list (and 1 more errors) (aligncheck, deadcode, golint, gosimple, interfacer, staticcheck, unconvert)
test.go:4:20:warning: unused global variable missing ',' before newline in argument list (and 1 more errors) (varcheck)
vet: test.go: test.go:4::warning: 20: missing ',' before newline in argument list (and 1 more errors) (vet, vetshadow)
test.go:4:20:error: missing ',' before newline in argument list (gotype)
test.go:5:3:error: expected ';', found 'EOF' (gotype, gotype)
test.go:5:3:error: expected '}', found 'EOF' (gotype)
test.go:5:3:error: missing ',' in argument list (gotype)
test.go:5:1:error: expected operand, found '}' (gotype)
test.go:5:3:error: expected ')', found 'EOF' (gotype)
```

@dominikh was it what you had in mind ?

NB: While the first commit is unrelated with the new option it allows to tests with a fork of this package. I can remove it if it's a problem.