### PR TITLE
Append -f and -u flags only with go get

### DIFF
--- a/main.go
+++ b/main.go
@@ -607,15 +607,16 @@ func makeInstallCommand(linters ...string) []string {
 	cmd := []string{"get"}
 	if config.VendoredLinters {
 		cmd = []string{"install"}
+	} else {
+		if config.Update {
+			cmd = append(cmd, "-u")
+		}
+		if config.Force {
+			cmd = append(cmd, "-f")
+		}
 	}
 	if config.Debug {
 		cmd = append(cmd, "-v")
-	}
-	if config.Update {
-		cmd = append(cmd, "-u")
-	}
-	if config.Force {
-		cmd = append(cmd, "-f")
 	}
 	cmd = append(cmd, linters...)
 	return cmd


### PR DESCRIPTION
## Why

When I executed `gometalinter --install --update` with the latest gometalinter, it raised error.

```
DEBUG: go install -v -u github.com/HewlettPackard/gas
flag provided but not defined: -u
usage: install [build flags] [packages]
```

`-u` flag and `-f` flag are not defined as `go build` flags.

## WHAT

Append these flags when `gometalinter install` is going to execute `go get`.