### PR TITLE
Fix issue when invalid linter is specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,10 @@ func (l *Linter) String() string {
 func LinterFromName(name string) *Linter {
 	s := linterDefinitions[name]
 	parts := strings.SplitN(s, ":", 2)
+	if len(parts) < 2 {
+		kingpin.FatalUsage("invalid linter: %q", name)
+	}
+
 	pattern := parts[1]
 	if p, ok := predefinedPatterns[pattern]; ok {
 		pattern = p

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func LinterFromName(name string) *Linter {
 	s := linterDefinitions[name]
 	parts := strings.SplitN(s, ":", 2)
 	if len(parts) < 2 {
-		kingpin.FatalUsage("invalid linter: %q", name)
+		kingpin.Fatalf("invalid linter: %q", name)
 	}
 
 	pattern := parts[1]


### PR DESCRIPTION
Running `gometalinter --enable=invalid` results in a panic and stack trace that don't really describe what the issue is:
```panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x26cb00, 0xc4200141e0)
	/go/src-1.7/src/runtime/panic.go:500 +0x1a1
main.LinterFromName(0x7fff5fbff1f6, 0x7, 0xc420051df0)
	/go/ext/src/github.com/alecthomas/gometalinter/main.go:63 +0x5ff
main.lintersFromFlags(0x0)
	/go/ext/src/github.com/alecthomas/gometalinter/main.go:713 +0x9e
main.main()
	/go/ext/src/github.com/alecthomas/gometalinter/main.go:290 +0x268
```
With this PR the result is ```gometalinter: error: invalid linter: "invalid"``` followed by the gometalinter usage.