### PR TITLE
Default concurrency to NumCPU.

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func init() {
 	kingpin.Flag("force", "Pass -f to go tool when installing.").Short('f').BoolVar(&config.Force)
 	kingpin.Flag("download-only", "Pass -d to go tool when installing.").BoolVar(&config.DownloadOnly)
 	kingpin.Flag("debug", "Display messages for failed linters, etc.").Short('d').BoolVar(&config.Debug)
-	kingpin.Flag("concurrency", "Number of concurrent linters to run.").PlaceHolder("16").Short('j').IntVar(&config.Concurrency)
+	kingpin.Flag("concurrency", "Number of concurrent linters to run.").PlaceHolder(strconv.Itoa(runtime.NumCPU())).Short('j').IntVar(&config.Concurrency)
 	kingpin.Flag("exclude", "Exclude messages matching these regular expressions.").Short('e').PlaceHolder("REGEXP").StringsVar(&config.Exclude)
 	kingpin.Flag("include", "Include messages matching these regular expressions.").Short('I').PlaceHolder("REGEXP").StringsVar(&config.Include)
 	kingpin.Flag("skip", "Skip directories with this name when expanding '...'.").Short('s').PlaceHolder("DIR...").StringsVar(&config.Skip)


### PR DESCRIPTION
No point in defaulting to a higher concurrency level than available CPUs since the checkers are heavy on computation. If anything, a lower default would be nice, perhaps at least one core less than NumCPU, so that editors calling out to gometalinter still have some CPU-time left for editing work while the checkers run in background, without having to pass additional parameters. Up to you and what use case you want to optimize for.