### PR TITLE
Configurable disable option

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,8 @@ type Config struct {
 	Linters map[string]string
 
 	// The set of linters that should be enabled.
-	Enable []string
+	Enable  []string
+	Disable []string
 
 	// A map of linter name to message that is displayed. This is useful when linters display text
 	// that is useful only in isolation, such as errcheck which just reports the construct.

--- a/main.go
+++ b/main.go
@@ -172,6 +172,13 @@ func loadConfig(element *kingpin.ParseElement, ctx *kingpin.ParseContext) error 
 	if config.DeadlineJSONCrutch != "" {
 		config.Deadline, err = time.ParseDuration(config.DeadlineJSONCrutch)
 	}
+	for _, disable := range config.Disable {
+		for i, enable := range config.Enable {
+			if enable == disable {
+				config.Enable = append(config.Enable[:i], config.Enable[i+1:]...)
+			}
+		}
+	}
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -176,6 +176,7 @@ func loadConfig(element *kingpin.ParseElement, ctx *kingpin.ParseContext) error 
 		for i, enable := range config.Enable {
 			if enable == disable {
 				config.Enable = append(config.Enable[:i], config.Enable[i+1:]...)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This change makes to support the following configuration file.

```json
{
  "Disable": [
    "golint",
    "gotype"
  ]
}
```

The configuration file disables `golint` and `gotype`. 