### PR TITLE
Human-readable linter output

### DIFF
--- a/config.go
+++ b/config.go
@@ -51,6 +51,8 @@ type Config struct { // nolint: aligncheck
 	EnableGC        bool
 	Aggregate       bool
 
+	Beautify bool `json:"-"`
+
 	DeadlineJSONCrutch string `json:"Deadline"`
 }
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/google/shlex"
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
@@ -160,6 +161,7 @@ func init() {
 	kingpin.Flag("checkstyle", "Generate checkstyle XML rather than standard line-based output.").BoolVar(&config.Checkstyle)
 	kingpin.Flag("enable-gc", "Enable GC for linters (useful on large repositories).").BoolVar(&config.EnableGC)
 	kingpin.Flag("aggregate", "Aggregate issues reported by several linters.").BoolVar(&config.Aggregate)
+	kingpin.Flag("beautify", "Display report with colors.").Short('b').BoolVar(&config.Beautify)
 	kingpin.CommandLine.GetFlag("help").Short('h')
 }
 
@@ -313,17 +315,22 @@ Severity override map (default is "warning"):
 	linters := lintersFromFlags()
 	status := 0
 	issues, errch := runLinters(linters, paths, *pathsArg, config.Concurrency, exclude, include)
+
 	if config.JSON {
 		status |= outputToJSON(issues)
 	} else if config.Checkstyle {
 		status |= outputToCheckstyle(issues)
+	} else if config.Beautify {
+		status |= outputToConsoleBeautiful(issues)
 	} else {
 		status |= outputToConsole(issues)
 	}
+
 	for err := range errch {
 		warning("%s", err)
 		status |= 2
 	}
+
 	elapsed := time.Since(start)
 	debug("total elapsed time %s", elapsed)
 	os.Exit(status)
@@ -379,15 +386,64 @@ https://github.com/alecthomas/gometalinter/issues/new
 	return include, exclude
 }
 
-func outputToConsole(issues chan *Issue) int {
-	status := 0
+func outputToConsoleBeautiful(issues chan *Issue) int {
+
+	var (
+		styleSeverityWarning = color.New(color.FgYellow).FprintFunc()
+		styleSeverityError   = color.New(color.FgRed).FprintFunc()
+
+		styleLocation = color.New(color.FgCyan, color.Underline).FprintFunc()
+		styleMessage  = color.New(color.FgMagenta).FprintFunc()
+		styleLinter   = color.New(color.Faint).FprintFunc()
+
+		status = 0
+		w      = new(bytes.Buffer)
+
+		swarning = " warning "
+		serror   = "  error   "
+	)
+
 	for issue := range issues {
 		if config.Errors && issue.Severity != Error {
 			continue
 		}
-		fmt.Println(issue.String())
+
+		if issue.Severity == Warning {
+			styleSeverityWarning(w, swarning)
+		} else {
+			styleSeverityError(w, serror)
+		}
+
+		styleLocation(w, issue.Path, ":", issue.Line)
+		w.WriteString(": ")
+		styleMessage(w, issue.Message)
+		w.WriteString(": ")
+		styleLinter(w, " (@", issue.Linter.Name, ")")
+
+		w.WriteByte('\n')
+		w.WriteTo(os.Stdout)
+		w.Reset()
+
 		status = 1
 	}
+
+	return status
+
+}
+
+func outputToConsole(issues chan *Issue) int {
+	status := 0
+
+	for issue := range issues {
+		if config.Errors && issue.Severity != Error {
+			continue
+		}
+
+		fmt.Println(issue.String())
+
+		status = 1
+	}
+
 	return status
 }
 


### PR DESCRIPTION
## Why?

Default output is good because it has a 	definite structure. It can easily be filtered by standard utilities or parsed by editors that does not support JSON native. 

The default output is good because it has a definite structure. It can easily be filtered by standard utilities or parsed by editors that do not support JSON natively. 

But it is not suitable for humans. Yeah, we can customize output using --format, but we can do it better. 

Let's compare:

### Default output

`gometalinter ./.`

![image](https://cloud.githubusercontent.com/assets/3163427/23333962/d13fb3a0-fb9d-11e6-89fe-aee87cca67d7.png)

### Human-readable output

`gometalinter -b ./.`

![image](https://cloud.githubusercontent.com/assets/3163427/23333967/f7e1b6ca-fb9d-11e6-8b47-6178a685380f.png)

### What is done?

Issue-per-line output with parts highlighting.
The current color scheme works great on light/dark backgrounds.
For colorize output I used `fatih/color` package. 
It can easily be replaced by regular constants with escape codes. 

### Ideas

 - handle `--aggregate` and `--sort` and show output like eslint

![image](https://cloud.githubusercontent.com/assets/3163427/23334024/238de6a8-fb9f-11e6-924b-2e341e09f7a3.png)



P. S. It's my first open-source contribution and I could do something wrong.

Wait for response. Thanks. 