### PR TITLE
Default concurrency to runtime.NumCPU()

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"runtime"
 	"text/template"
 	"time"
 
@@ -171,7 +172,7 @@ var (
 			"vetshadow",
 		},
 		VendoredLinters: true,
-		Concurrency:     16,
+		Concurrency:     runtime.NumCPU(),
 		Cyclo:           10,
 		LineLength:      80,
 		MinConfidence:   0.8,


### PR DESCRIPTION
Currently the `gometalinter --help` indicates that the default value is `runtime.NumCPU()`.
I get this indication from the [placeholder](https://github.com/alecthomas/gometalinter/blob/2c137d148e40e95c566bc68eda12ea21d222e7a8/main.go#L145).

It also runs much better if you don't use `16` threads on a machine that only has 4 cores :) hehe
It was pretty much sucking all the I/O out of my laptop when running some of the more expensive linters like `interfacer`.

I suspect this will be a good default for people running in travis too.

Note: it could also be `runtime.NumCPU()*2`, but since most laptops these days have N cores N*2 logical cores (due to hyper threading), `runtime.NumCPU()` is probably going to be fine.