### PR TITLE
Fix the linterState.fixPath issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -727,6 +727,11 @@ func executeLinter(state *linterState) error {
 func (l *linterState) fixPath(path string) string {
 	lpath := strings.TrimSuffix(l.path, "...")
 	labspath, _ := filepath.Abs(lpath)
+
+	if !l.ShouldChdir() {
+		path = strings.TrimPrefix(path, lpath)
+	}
+
 	if !filepath.IsAbs(path) {
 		path, _ = filepath.Abs(filepath.Join(labspath, path))
 	}


### PR DESCRIPTION
This should fix the `linterState.fixPath` issue
Found this on *golint* only when using ellipsis on the path ex: `src/github.com/uudashr/fibgo/...`

The fixPath return `src/github.com/uudashr/fibgo/src/github.com/uudashr/fibgo/fib.go` 
while expecting `src/github.com/uudashr/fibgo/fib.go`

Before fix, the debug result:
```
./bin/gometalinter --disable-all --enable=golint --debug src/github.com/uudashr/fibgo/...
DEBUG: PATH=/Users/uudashr/.rbenv/shims:/Users/uudashr/google-cloud-sdk/bin:/Users/uudashr/Applications/apache-maven-3.3.9/bin:/Users/uudashr/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/uudashr/Library/Python/2.7/bin
DEBUG: GOPATH=/Users/uudashr/go
DEBUG: GOBIN=
DEBUG: linting path src/github.com/uudashr/fibgo
DEBUG: linting path src/github.com/uudashr/fibgo/cmd/fibgo-server
DEBUG: linting with golint: golint -min_confidence {min_confidence} {path} (on src/github.com/uudashr/fibgo/...)
DEBUG: executing /Users/uudashr/go/bin/golint ["-min_confidence" "0.800000" "src/github.com/uudashr/fibgo/..."]
DEBUG: golint hits 1: ^(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$
DEBUG: golint linter took 39.201697ms
DEBUG: nolint: parsing src/github.com/uudashr/fibgo/src/github.com/uudashr/fibgo/fib.go for directives
DEBUG: nolint: failed to parse "src/github.com/uudashr/fibgo/src/github.com/uudashr/fibgo/fib.go": open src/github.com/uudashr/fibgo/src/github.com/uudashr/fibgo/fib.go: no such file or directory
src/github.com/uudashr/fibgo/src/github.com/uudashr/fibgo/fib.go:32:1:warning: exported function Seq should have comment or be unexported (golint)
DEBUG: total elapsed time 52.118335ms
```

After fix:
```
./bin/gometalinter --disable-all --enable=golint --debug src/github.com/uudashr/fibgo/...
DEBUG: PATH=/Users/uudashr/.rbenv/shims:/Users/uudashr/google-cloud-sdk/bin:/Users/uudashr/Applications/apache-maven-3.3.9/bin:/Users/uudashr/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/uudashr/Library/Python/2.7/bin
DEBUG: GOPATH=/Users/uudashr/go
DEBUG: GOBIN=
DEBUG: linting path src/github.com/uudashr/fibgo
DEBUG: linting path src/github.com/uudashr/fibgo/cmd/fibgo-server
DEBUG: linting with golint: golint -min_confidence {min_confidence} {path} (on src/github.com/uudashr/fibgo/...)
DEBUG: executing /Users/uudashr/go/bin/golint ["-min_confidence" "0.800000" "src/github.com/uudashr/fibgo/..."]
DEBUG: golint hits 1: ^(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$
DEBUG: golint linter took 57.650493ms
DEBUG: nolint: parsing src/github.com/uudashr/fibgo/fib.go for directives
DEBUG: nolint: parsing src/github.com/uudashr/fibgo/fib.go took 385.687µs
src/github.com/uudashr/fibgo/fib.go:32:1:warning: exported function Seq should have comment or be unexported (golint)
DEBUG: total elapsed time 64.227014ms
```
