### PR TITLE
Use a duration type instead of deadline crutch

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"io/ioutil"
 	"sort"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
 
 func TestSortedIssues(t *testing.T) {
@@ -26,4 +30,23 @@ func TestSortedIssues(t *testing.T) {
 		{Path: "b.go", Line: 5},
 	}
 	require.Equal(t, expected, actual)
+}
+
+func TestLoadConfigWithDeadline(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	tmpfile, err := ioutil.TempFile("", "test-config")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(`{"Deadline": "3m"}`))
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+
+	filename := tmpfile.Name()
+	err = loadConfig(nil, &kingpin.ParseElement{Value: &filename}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 3 * time.Minute, config.Deadline.Duration())
 }


### PR DESCRIPTION
This change replaces the `DeadlineJSONCrutch` with a type which handles serializing from a JSON string to a `time.Duration()`. Also adds a test to cover the change.