### PR TITLE
config: Do not run "go tool vet" on files

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,8 +98,6 @@ var (
 		"goimports",
 		"lll",
 		"misspell",
-		"vet",
-		"vetshadow",
 	}...)
 
 	// Linter definitions.


### PR DESCRIPTION
"go tool vet" can only be used on a set of files if they are all in the
same package. It however can be used on a set of directories or package
paths.

Fixes: #307

Signed-off-by: Rob Bradford <robert.bradford@intel.com>