### PR TITLE
Split main package into more files

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/shlex"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
+)
+
+type Vars map[string]string
+
+func (v Vars) Copy() Vars {
+	out := Vars{}
+	for k, v := range v {
+		out[k] = v
+	}
+	return out
+}
+
+func (v Vars) Replace(s string) string {
+	for k, v := range v {
+		prefix := regexp.MustCompile(fmt.Sprintf("{%s=([^}]*)}", k))
+		if v != "" {
+			s = prefix.ReplaceAllString(s, "$1")
+		} else {
+			s = prefix.ReplaceAllString(s, "")
+		}
+		s = strings.Replace(s, fmt.Sprintf("{%s}", k), v, -1)
+	}
+	return s
+}
+
+// Severity of linter message.
+type Severity string
+
+// Linter message severity levels.
+const ( // nolint: deadcode
+	Error   Severity = "error"
+	Warning Severity = "warning"
+)
+
+type Issue struct {
+	Linter   *Linter  `json:"linter"`
+	Severity Severity `json:"severity"`
+	Path     string   `json:"path"`
+	Line     int      `json:"line"`
+	Col      int      `json:"col"`
+	Message  string   `json:"message"`
+}
+
+func (i *Issue) String() string {
+	buf := new(bytes.Buffer)
+	err := formatTemplate.Execute(buf, i)
+	kingpin.FatalIfError(err, "Invalid output format")
+	return buf.String()
+}
+
+type linterState struct {
+	*Linter
+	path     string
+	issues   chan *Issue
+	vars     Vars
+	exclude  *regexp.Regexp
+	include  *regexp.Regexp
+	deadline <-chan time.Time
+}
+
+func (l *linterState) InterpolatedCommand() string {
+	vars := l.vars.Copy()
+	if l.ShouldChdir() {
+		vars["path"] = "."
+	} else {
+		vars["path"] = l.path
+	}
+	return vars.Replace(l.Command)
+}
+
+func (l *linterState) ShouldChdir() bool {
+	return config.Vendor || !strings.HasSuffix(l.path, "/...") || !strings.Contains(l.Command, "{path}")
+}
+
+func (l *linterState) fixPath(path string) string {
+	lpath := strings.TrimSuffix(l.path, "...")
+	labspath, _ := filepath.Abs(lpath)
+
+	if !l.ShouldChdir() {
+		path = strings.TrimPrefix(path, lpath)
+	}
+
+	if !filepath.IsAbs(path) {
+		path, _ = filepath.Abs(filepath.Join(labspath, path))
+	}
+	if strings.HasPrefix(path, labspath) {
+		return filepath.Join(lpath, strings.TrimPrefix(path, labspath))
+	}
+	return path
+}
+
+func runLinters(linters map[string]*Linter, paths, ellipsisPaths []string, concurrency int, exclude *regexp.Regexp, include *regexp.Regexp) (chan *Issue, chan error) {
+	errch := make(chan error, len(linters)*(len(paths)+len(ellipsisPaths)))
+	concurrencych := make(chan bool, concurrency)
+	incomingIssues := make(chan *Issue, 1000000)
+	directives := newDirectiveParser()
+	processedIssues := filterIssuesViaDirectives(directives, maybeSortIssues(maybeAggregateIssues(incomingIssues)))
+	wg := &sync.WaitGroup{}
+	for _, linter := range linters {
+		// Recreated in each loop because it is mutated by executeLinter().
+		vars := Vars{
+			"duplthreshold":    fmt.Sprintf("%d", config.DuplThreshold),
+			"mincyclo":         fmt.Sprintf("%d", config.Cyclo),
+			"maxlinelength":    fmt.Sprintf("%d", config.LineLength),
+			"min_confidence":   fmt.Sprintf("%f", config.MinConfidence),
+			"min_occurrences":  fmt.Sprintf("%d", config.MinOccurrences),
+			"min_const_length": fmt.Sprintf("%d", config.MinConstLength),
+			"tests":            "",
+		}
+		if config.Test {
+			vars["tests"] = "-t"
+		}
+		linterPaths := paths
+		// Most linters don't exclude vendor paths when recursing, so we don't use ... paths.
+		if acceptsEllipsis[linter.Name] && !config.Vendor && len(ellipsisPaths) > 0 {
+			linterPaths = ellipsisPaths
+		}
+		for _, path := range linterPaths {
+			wg.Add(1)
+			deadline := time.After(config.Deadline)
+			state := &linterState{
+				Linter:   linter,
+				issues:   incomingIssues,
+				path:     path,
+				vars:     vars.Copy(),
+				exclude:  exclude,
+				include:  include,
+				deadline: deadline,
+			}
+			go func() {
+				concurrencych <- true
+				err := executeLinter(state)
+				if err != nil {
+					errch <- err
+				}
+				<-concurrencych
+				wg.Done()
+			}()
+		}
+	}
+
+	go func() {
+		wg.Wait()
+		close(incomingIssues)
+		close(errch)
+	}()
+	return processedIssues, errch
+}
+
+func executeLinter(state *linterState) error {
+	debug("linting with %s: %s (on %s)", state.Name, state.Command, state.path)
+
+	start := time.Now()
+	command := state.InterpolatedCommand()
+	exe, args, err := parseCommand(state.path, command)
+	if err != nil {
+		return err
+	}
+	debug("executing %s %q", exe, args)
+	buf := bytes.NewBuffer(nil)
+	cmd := exec.Command(exe, args...) // nolint: gas
+	if state.ShouldChdir() {
+		cmd.Dir = state.path
+	}
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("failed to execute linter %s: %s", command, err)
+	}
+
+	done := make(chan bool)
+	go func() {
+		err = cmd.Wait()
+		done <- true
+	}()
+
+	// Wait for process to complete or deadline to expire.
+	select {
+	case <-done:
+
+	case <-state.deadline:
+		err = fmt.Errorf("deadline exceeded by linter %s on %s (try increasing --deadline)",
+			state.Name, state.path)
+		kerr := cmd.Process.Kill()
+		if kerr != nil {
+			warning("failed to kill %s: %s", state.Name, kerr)
+		}
+		return err
+	}
+
+	if err != nil {
+		debug("warning: %s returned %s", command, err)
+	}
+
+	processOutput(state, buf.Bytes())
+	elapsed := time.Since(start)
+	debug("%s linter took %s", state.Name, elapsed)
+	return nil
+}
+
+func parseCommand(dir, command string) (string, []string, error) {
+	args, err := shlex.Split(command)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(args) == 0 {
+		return "", nil, fmt.Errorf("invalid command %q", command)
+	}
+	exe, err := exec.LookPath(args[0])
+	if err != nil {
+		return "", nil, err
+	}
+	out := []string{}
+	for _, arg := range args[1:] {
+		if strings.Contains(arg, "*") {
+			pattern := filepath.Join(dir, arg)
+			globbed, err := filepath.Glob(pattern)
+			if err != nil {
+				return "", nil, err
+			}
+			for i, g := range globbed {
+				if strings.HasPrefix(g, dir+string(filepath.Separator)) {
+					globbed[i] = g[len(dir)+1:]
+				}
+			}
+			out = append(out, globbed...)
+		} else {
+			out = append(out, arg)
+		}
+	}
+	return exe, out, nil
+}
+
+// nolint: gocyclo
+func processOutput(state *linterState, out []byte) {
+	re := state.regex
+	all := re.FindAllSubmatchIndex(out, -1)
+	debug("%s hits %d: %s", state.Name, len(all), state.Pattern)
+	for _, indices := range all {
+		group := [][]byte{}
+		for i := 0; i < len(indices); i += 2 {
+			var fragment []byte
+			if indices[i] != -1 {
+				fragment = out[indices[i]:indices[i+1]]
+			}
+			group = append(group, fragment)
+		}
+
+		issue := &Issue{Line: 1}
+		issue.Linter = LinterFromName(state.Name)
+		for i, name := range re.SubexpNames() {
+			if group[i] == nil {
+				continue
+			}
+			part := string(group[i])
+			if name != "" {
+				state.vars[name] = part
+			}
+			switch name {
+			case "path":
+				issue.Path = state.fixPath(part)
+
+			case "line":
+				n, err := strconv.ParseInt(part, 10, 32)
+				kingpin.FatalIfError(err, "line matched invalid integer")
+				issue.Line = int(n)
+
+			case "col":
+				n, err := strconv.ParseInt(part, 10, 32)
+				kingpin.FatalIfError(err, "col matched invalid integer")
+				issue.Col = int(n)
+
+			case "message":
+				issue.Message = part
+
+			case "":
+			}
+		}
+		if m, ok := config.MessageOverride[state.Name]; ok {
+			issue.Message = state.vars.Replace(m)
+		}
+		if sev, ok := config.Severity[state.Name]; ok {
+			issue.Severity = Severity(sev)
+		} else {
+			issue.Severity = "warning"
+		}
+		if state.exclude != nil && state.exclude.MatchString(issue.String()) {
+			continue
+		}
+		if state.include != nil && !state.include.MatchString(issue.String()) {
+			continue
+		}
+		state.issues <- issue
+	}
+	return
+}
+
+func maybeAggregateIssues(issues chan *Issue) chan *Issue {
+	if !config.Aggregate {
+		return issues
+	}
+	return aggregateIssues(issues)
+}
+
+type sortedIssues struct {
+	issues []*Issue
+	order  []string
+}
+
+func (s *sortedIssues) Len() int      { return len(s.issues) }
+func (s *sortedIssues) Swap(i, j int) { s.issues[i], s.issues[j] = s.issues[j], s.issues[i] }
+
+// nolint: gocyclo
+func (s *sortedIssues) Less(i, j int) bool {
+	l, r := s.issues[i], s.issues[j]
+	for _, key := range s.order {
+		switch key {
+		case "path":
+			if l.Path > r.Path {
+				return false
+			}
+		case "line":
+			if l.Line > r.Line {
+				return false
+			}
+		case "column":
+			if l.Col > r.Col {
+				return false
+			}
+		case "severity":
+			if l.Severity > r.Severity {
+				return false
+			}
+		case "message":
+			if l.Message > r.Message {
+				return false
+			}
+		case "linter":
+			if l.Linter.Name > r.Linter.Name {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func maybeSortIssues(issues chan *Issue) chan *Issue {
+	if reflect.DeepEqual([]string{"none"}, config.Sort) {
+		return issues
+	}
+	out := make(chan *Issue, 1000000)
+	sorted := &sortedIssues{
+		issues: []*Issue{},
+		order:  config.Sort,
+	}
+	go func() {
+		for issue := range issues {
+			sorted.issues = append(sorted.issues, issue)
+		}
+		sort.Sort(sorted)
+		for _, issue := range sorted.issues {
+			out <- issue
+		}
+		close(out)
+	}()
+	return out
+}

--- a/linters.go
+++ b/linters.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
+)
+
+type Linter struct {
+	Name             string   `json:"name"`
+	Command          string   `json:"command"`
+	Pattern          string   `json:"pattern"`
+	InstallFrom      string   `json:"install_from"`
+	SeverityOverride Severity `json:"severity,omitempty"`
+	MessageOverride  string   `json:"message_override,omitempty"`
+
+	regex *regexp.Regexp
+}
+
+func (l *Linter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.Name)
+}
+
+func (l *Linter) String() string {
+	return l.Name
+}
+
+func LinterFromName(name string) *Linter {
+	s := linterDefinitions[name]
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) < 2 {
+		kingpin.Fatalf("invalid linter: %q", name)
+	}
+
+	pattern := parts[1]
+	if p, ok := predefinedPatterns[pattern]; ok {
+		pattern = p
+	}
+	re, err := regexp.Compile("(?m:" + pattern + ")")
+	kingpin.FatalIfError(err, "invalid regex for %q", name)
+	return &Linter{
+		Name:             name,
+		Command:          s[0:strings.Index(s, ":")],
+		Pattern:          pattern,
+		InstallFrom:      installMap[name],
+		SeverityOverride: Severity(config.Severity[name]),
+		MessageOverride:  config.MessageOverride[name],
+		regex:            re,
+	}
+}
+
+func makeInstallCommand(linters ...string) []string {
+	cmd := []string{"get"}
+	if config.VendoredLinters {
+		cmd = []string{"install"}
+	} else {
+		if config.Update {
+			cmd = append(cmd, "-u")
+		}
+		if config.Force {
+			cmd = append(cmd, "-f")
+		}
+		if config.DownloadOnly {
+			cmd = append(cmd, "-d")
+		}
+	}
+	if config.Debug {
+		cmd = append(cmd, "-v")
+	}
+	cmd = append(cmd, linters...)
+	return cmd
+}
+
+func installLintersWithOneCommand(targets []string) error {
+	cmd := makeInstallCommand(targets...)
+	debug("go %s", strings.Join(cmd, " "))
+	c := exec.Command("go", cmd...) // nolint: gas
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+func installLintersIndividually(targets []string) {
+	failed := []string{}
+	for _, target := range targets {
+		cmd := makeInstallCommand(target)
+		debug("go %s", strings.Join(cmd, " "))
+		c := exec.Command("go", cmd...) // nolint: gas
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			warning("failed to install %s: %s", target, err)
+			failed = append(failed, target)
+		}
+	}
+	if len(failed) > 0 {
+		kingpin.Fatalf("failed to install the following linters: %s", strings.Join(failed, ", "))
+	}
+}
+
+func installLinters() {
+	names := make([]string, 0, len(installMap))
+	targets := make([]string, 0, len(installMap))
+	for name, target := range installMap {
+		names = append(names, name)
+		targets = append(targets, target)
+	}
+	namesStr := strings.Join(names, "\n  ")
+	if config.DownloadOnly {
+		fmt.Printf("Downloading:\n  %s\n", namesStr)
+	} else {
+		fmt.Printf("Installing:\n  %s\n", namesStr)
+	}
+	err := installLintersWithOneCommand(targets)
+	if err == nil {
+		return
+	}
+	warning("failed to install one or more linters: %s (installing individually)", err)
+	installLintersIndividually(targets)
+}

--- a/main.go
+++ b/main.go
@@ -5,30 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
-	"sync"
 	"text/template"
 	"time"
 
-	"github.com/google/shlex"
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
-)
-
-// Severity of linter message.
-type Severity string
-
-// Linter message severity levels.
-const ( // nolint: deadcode
-	Error   Severity = "error"
-	Warning Severity = "warning"
 )
 
 var (
@@ -38,91 +24,6 @@ var (
 		{"gopkg.in", "alecthomas", "gometalinter.v1", "_linters"},
 	}
 )
-
-type Linter struct {
-	Name             string   `json:"name"`
-	Command          string   `json:"command"`
-	Pattern          string   `json:"pattern"`
-	InstallFrom      string   `json:"install_from"`
-	SeverityOverride Severity `json:"severity,omitempty"`
-	MessageOverride  string   `json:"message_override,omitempty"`
-
-	regex *regexp.Regexp
-}
-
-func (l *Linter) MarshalJSON() ([]byte, error) {
-	return json.Marshal(l.Name)
-}
-
-func (l *Linter) String() string {
-	return l.Name
-}
-
-func LinterFromName(name string) *Linter {
-	s := linterDefinitions[name]
-	parts := strings.SplitN(s, ":", 2)
-	if len(parts) < 2 {
-		kingpin.Fatalf("invalid linter: %q", name)
-	}
-
-	pattern := parts[1]
-	if p, ok := predefinedPatterns[pattern]; ok {
-		pattern = p
-	}
-	re, err := regexp.Compile("(?m:" + pattern + ")")
-	kingpin.FatalIfError(err, "invalid regex for %q", name)
-	return &Linter{
-		Name:             name,
-		Command:          s[0:strings.Index(s, ":")],
-		Pattern:          pattern,
-		InstallFrom:      installMap[name],
-		SeverityOverride: Severity(config.Severity[name]),
-		MessageOverride:  config.MessageOverride[name],
-		regex:            re,
-	}
-}
-
-type sortedIssues struct {
-	issues []*Issue
-	order  []string
-}
-
-func (s *sortedIssues) Len() int      { return len(s.issues) }
-func (s *sortedIssues) Swap(i, j int) { s.issues[i], s.issues[j] = s.issues[j], s.issues[i] }
-
-// nolint: gocyclo
-func (s *sortedIssues) Less(i, j int) bool {
-	l, r := s.issues[i], s.issues[j]
-	for _, key := range s.order {
-		switch key {
-		case "path":
-			if l.Path > r.Path {
-				return false
-			}
-		case "line":
-			if l.Line > r.Line {
-				return false
-			}
-		case "column":
-			if l.Col > r.Col {
-				return false
-			}
-		case "severity":
-			if l.Severity > r.Severity {
-				return false
-			}
-		case "message":
-			if l.Message > r.Message {
-				return false
-			}
-		case "linter":
-			if l.Linter.Name > r.Linter.Name {
-				return false
-			}
-		}
-	}
-	return true
-}
 
 func init() {
 	kingpin.Flag("config", "Load JSON configuration from file.").Action(loadConfig).String()
@@ -215,22 +116,6 @@ func enableAllAction(app *kingpin.Application, element *kingpin.ParseElement, ct
 	return nil
 }
 
-type Issue struct {
-	Linter   *Linter  `json:"linter"`
-	Severity Severity `json:"severity"`
-	Path     string   `json:"path"`
-	Line     int      `json:"line"`
-	Col      int      `json:"col"`
-	Message  string   `json:"message"`
-}
-
-func (i *Issue) String() string {
-	buf := new(bytes.Buffer)
-	err := formatTemplate.Execute(buf, i)
-	kingpin.FatalIfError(err, "Invalid output format")
-	return buf.String()
-}
-
 func debug(format string, args ...interface{}) {
 	if config.Debug {
 		fmt.Fprintf(os.Stderr, "DEBUG: "+format+"\n", args...)
@@ -260,29 +145,6 @@ func formatSeverity() string {
 		fmt.Fprintf(w, "  %s -> %s\n", name, severity)
 	}
 	return w.String()
-}
-
-type Vars map[string]string
-
-func (v Vars) Copy() Vars {
-	out := Vars{}
-	for k, v := range v {
-		out[k] = v
-	}
-	return out
-}
-
-func (v Vars) Replace(s string) string {
-	for k, v := range v {
-		prefix := regexp.MustCompile(fmt.Sprintf("{%s=([^}]*)}", k))
-		if v != "" {
-			s = prefix.ReplaceAllString(s, "$1")
-		} else {
-			s = prefix.ReplaceAllString(s, "")
-		}
-		s = strings.Replace(s, fmt.Sprintf("{%s}", k), v, -1)
-	}
-	return s
 }
 
 func main() {
@@ -412,64 +274,6 @@ func outputToJSON(issues chan *Issue) int {
 	return status
 }
 
-func runLinters(linters map[string]*Linter, paths, ellipsisPaths []string, concurrency int, exclude *regexp.Regexp, include *regexp.Regexp) (chan *Issue, chan error) {
-	errch := make(chan error, len(linters)*(len(paths)+len(ellipsisPaths)))
-	concurrencych := make(chan bool, concurrency)
-	incomingIssues := make(chan *Issue, 1000000)
-	directives := newDirectiveParser()
-	processedIssues := filterIssuesViaDirectives(directives, maybeSortIssues(maybeAggregateIssues(incomingIssues)))
-	wg := &sync.WaitGroup{}
-	for _, linter := range linters {
-		// Recreated in each loop because it is mutated by executeLinter().
-		vars := Vars{
-			"duplthreshold":    fmt.Sprintf("%d", config.DuplThreshold),
-			"mincyclo":         fmt.Sprintf("%d", config.Cyclo),
-			"maxlinelength":    fmt.Sprintf("%d", config.LineLength),
-			"min_confidence":   fmt.Sprintf("%f", config.MinConfidence),
-			"min_occurrences":  fmt.Sprintf("%d", config.MinOccurrences),
-			"min_const_length": fmt.Sprintf("%d", config.MinConstLength),
-			"tests":            "",
-		}
-		if config.Test {
-			vars["tests"] = "-t"
-		}
-		linterPaths := paths
-		// Most linters don't exclude vendor paths when recursing, so we don't use ... paths.
-		if acceptsEllipsis[linter.Name] && !config.Vendor && len(ellipsisPaths) > 0 {
-			linterPaths = ellipsisPaths
-		}
-		for _, path := range linterPaths {
-			wg.Add(1)
-			deadline := time.After(config.Deadline)
-			state := &linterState{
-				Linter:   linter,
-				issues:   incomingIssues,
-				path:     path,
-				vars:     vars.Copy(),
-				exclude:  exclude,
-				include:  include,
-				deadline: deadline,
-			}
-			go func() {
-				concurrencych <- true
-				err := executeLinter(state)
-				if err != nil {
-					errch <- err
-				}
-				<-concurrencych
-				wg.Done()
-			}()
-		}
-	}
-
-	go func() {
-		wg.Wait()
-		close(incomingIssues)
-		close(errch)
-	}()
-	return processedIssues, errch
-}
-
 // nolint: gocyclo
 func expandPaths(paths, skip []string) []string {
 	if len(paths) == 0 {
@@ -513,231 +317,6 @@ func expandPaths(paths, skip []string) []string {
 		debug("linting path %s", d)
 	}
 	return out
-}
-
-func makeInstallCommand(linters ...string) []string {
-	cmd := []string{"get"}
-	if config.VendoredLinters {
-		cmd = []string{"install"}
-	} else {
-		if config.Update {
-			cmd = append(cmd, "-u")
-		}
-		if config.Force {
-			cmd = append(cmd, "-f")
-		}
-		if config.DownloadOnly {
-			cmd = append(cmd, "-d")
-		}
-	}
-	if config.Debug {
-		cmd = append(cmd, "-v")
-	}
-	cmd = append(cmd, linters...)
-	return cmd
-}
-
-func installLintersWithOneCommand(targets []string) error {
-	cmd := makeInstallCommand(targets...)
-	debug("go %s", strings.Join(cmd, " "))
-	c := exec.Command("go", cmd...) // nolint: gas
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	return c.Run()
-}
-
-func installLintersIndividually(targets []string) {
-	failed := []string{}
-	for _, target := range targets {
-		cmd := makeInstallCommand(target)
-		debug("go %s", strings.Join(cmd, " "))
-		c := exec.Command("go", cmd...) // nolint: gas
-		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
-		if err := c.Run(); err != nil {
-			warning("failed to install %s: %s", target, err)
-			failed = append(failed, target)
-		}
-	}
-	if len(failed) > 0 {
-		kingpin.Fatalf("failed to install the following linters: %s", strings.Join(failed, ", "))
-	}
-}
-
-func installLinters() {
-	names := make([]string, 0, len(installMap))
-	targets := make([]string, 0, len(installMap))
-	for name, target := range installMap {
-		names = append(names, name)
-		targets = append(targets, target)
-	}
-	namesStr := strings.Join(names, "\n  ")
-	if config.DownloadOnly {
-		fmt.Printf("Downloading:\n  %s\n", namesStr)
-	} else {
-		fmt.Printf("Installing:\n  %s\n", namesStr)
-	}
-	err := installLintersWithOneCommand(targets)
-	if err == nil {
-		return
-	}
-	warning("failed to install one or more linters: %s (installing individually)", err)
-	installLintersIndividually(targets)
-}
-
-func maybeAggregateIssues(issues chan *Issue) chan *Issue {
-	if !config.Aggregate {
-		return issues
-	}
-	return aggregateIssues(issues)
-}
-
-func maybeSortIssues(issues chan *Issue) chan *Issue {
-	if reflect.DeepEqual([]string{"none"}, config.Sort) {
-		return issues
-	}
-	out := make(chan *Issue, 1000000)
-	sorted := &sortedIssues{
-		issues: []*Issue{},
-		order:  config.Sort,
-	}
-	go func() {
-		for issue := range issues {
-			sorted.issues = append(sorted.issues, issue)
-		}
-		sort.Sort(sorted)
-		for _, issue := range sorted.issues {
-			out <- issue
-		}
-		close(out)
-	}()
-	return out
-}
-
-type linterState struct {
-	*Linter
-	path     string
-	issues   chan *Issue
-	vars     Vars
-	exclude  *regexp.Regexp
-	include  *regexp.Regexp
-	deadline <-chan time.Time
-}
-
-func (l *linterState) InterpolatedCommand() string {
-	vars := l.vars.Copy()
-	if l.ShouldChdir() {
-		vars["path"] = "."
-	} else {
-		vars["path"] = l.path
-	}
-	return vars.Replace(l.Command)
-}
-
-func (l *linterState) ShouldChdir() bool {
-	return config.Vendor || !strings.HasSuffix(l.path, "/...") || !strings.Contains(l.Command, "{path}")
-}
-
-func parseCommand(dir, command string) (string, []string, error) {
-	args, err := shlex.Split(command)
-	if err != nil {
-		return "", nil, err
-	}
-	if len(args) == 0 {
-		return "", nil, fmt.Errorf("invalid command %q", command)
-	}
-	exe, err := exec.LookPath(args[0])
-	if err != nil {
-		return "", nil, err
-	}
-	out := []string{}
-	for _, arg := range args[1:] {
-		if strings.Contains(arg, "*") {
-			pattern := filepath.Join(dir, arg)
-			globbed, err := filepath.Glob(pattern)
-			if err != nil {
-				return "", nil, err
-			}
-			for i, g := range globbed {
-				if strings.HasPrefix(g, dir+string(filepath.Separator)) {
-					globbed[i] = g[len(dir)+1:]
-				}
-			}
-			out = append(out, globbed...)
-		} else {
-			out = append(out, arg)
-		}
-	}
-	return exe, out, nil
-}
-
-func executeLinter(state *linterState) error {
-	debug("linting with %s: %s (on %s)", state.Name, state.Command, state.path)
-
-	start := time.Now()
-	command := state.InterpolatedCommand()
-	exe, args, err := parseCommand(state.path, command)
-	if err != nil {
-		return err
-	}
-	debug("executing %s %q", exe, args)
-	buf := bytes.NewBuffer(nil)
-	cmd := exec.Command(exe, args...) // nolint: gas
-	if state.ShouldChdir() {
-		cmd.Dir = state.path
-	}
-	cmd.Stdout = buf
-	cmd.Stderr = buf
-	err = cmd.Start()
-	if err != nil {
-		return fmt.Errorf("failed to execute linter %s: %s", command, err)
-	}
-
-	done := make(chan bool)
-	go func() {
-		err = cmd.Wait()
-		done <- true
-	}()
-
-	// Wait for process to complete or deadline to expire.
-	select {
-	case <-done:
-
-	case <-state.deadline:
-		err = fmt.Errorf("deadline exceeded by linter %s on %s (try increasing --deadline)",
-			state.Name, state.path)
-		kerr := cmd.Process.Kill()
-		if kerr != nil {
-			warning("failed to kill %s: %s", state.Name, kerr)
-		}
-		return err
-	}
-
-	if err != nil {
-		debug("warning: %s returned %s", command, err)
-	}
-
-	processOutput(state, buf.Bytes())
-	elapsed := time.Since(start)
-	debug("%s linter took %s", state.Name, elapsed)
-	return nil
-}
-
-func (l *linterState) fixPath(path string) string {
-	lpath := strings.TrimSuffix(l.path, "...")
-	labspath, _ := filepath.Abs(lpath)
-
-	if !l.ShouldChdir() {
-		path = strings.TrimPrefix(path, lpath)
-	}
-
-	if !filepath.IsAbs(path) {
-		path, _ = filepath.Abs(filepath.Join(labspath, path))
-	}
-	if strings.HasPrefix(path, labspath) {
-		return filepath.Join(lpath, strings.TrimPrefix(path, labspath))
-	}
-	return path
 }
 
 func lintersFromFlags() map[string]*Linter {
@@ -787,70 +366,6 @@ func replaceWithMegacheck(enabled []string) []string {
 		return append(revised, "megacheck")
 	}
 	return enabled
-}
-
-// nolint: gocyclo
-func processOutput(state *linterState, out []byte) {
-	re := state.regex
-	all := re.FindAllSubmatchIndex(out, -1)
-	debug("%s hits %d: %s", state.Name, len(all), state.Pattern)
-	for _, indices := range all {
-		group := [][]byte{}
-		for i := 0; i < len(indices); i += 2 {
-			var fragment []byte
-			if indices[i] != -1 {
-				fragment = out[indices[i]:indices[i+1]]
-			}
-			group = append(group, fragment)
-		}
-
-		issue := &Issue{Line: 1}
-		issue.Linter = LinterFromName(state.Name)
-		for i, name := range re.SubexpNames() {
-			if group[i] == nil {
-				continue
-			}
-			part := string(group[i])
-			if name != "" {
-				state.vars[name] = part
-			}
-			switch name {
-			case "path":
-				issue.Path = state.fixPath(part)
-
-			case "line":
-				n, err := strconv.ParseInt(part, 10, 32)
-				kingpin.FatalIfError(err, "line matched invalid integer")
-				issue.Line = int(n)
-
-			case "col":
-				n, err := strconv.ParseInt(part, 10, 32)
-				kingpin.FatalIfError(err, "col matched invalid integer")
-				issue.Col = int(n)
-
-			case "message":
-				issue.Message = part
-
-			case "":
-			}
-		}
-		if m, ok := config.MessageOverride[state.Name]; ok {
-			issue.Message = state.vars.Replace(m)
-		}
-		if sev, ok := config.Severity[state.Name]; ok {
-			issue.Severity = Severity(sev)
-		} else {
-			issue.Severity = "warning"
-		}
-		if state.exclude != nil && state.exclude.MatchString(issue.String()) {
-			continue
-		}
-		if state.include != nil && !state.include.MatchString(issue.String()) {
-			continue
-		}
-		state.issues <- issue
-	}
-	return
 }
 
 func findVendoredLinters() string {

--- a/regressiontests/support.go
+++ b/regressiontests/support.go
@@ -1,6 +1,7 @@
 package regressiontests
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Issue struct {
@@ -42,32 +44,28 @@ func (e Issues) Less(i, j int) bool { return e[i].String() < e[j].String() }
 func ExpectIssues(t *testing.T, linter string, source string, expected Issues, extraFlags ...string) {
 	// Write source to temporary directory.
 	dir, err := ioutil.TempDir(".", "gometalinter-")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	w, err := os.Create(filepath.Join(dir, "test.go"))
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.Remove(w.Name())
-	_, err = w.WriteString(source)
-	_ = w.Close()
-	if !assert.NoError(t, err) {
-		return
-	}
+
+	testFile := filepath.Join(dir, "test.go")
+	err = ioutil.WriteFile(testFile, []byte(source), 0644)
+	require.NoError(t, err)
 
 	// Run gometalinter.
-	args := []string{"go", "run", "../main.go", "../directives.go", "../config.go", "../checkstyle.go", "../aggregate.go", "--disable-all", "--enable", linter, "--json", dir}
+	binary, cleanup := buildBinary(t)
+	defer cleanup()
+	args := []string{"-d", "--disable-all", "--enable", linter, "--json", dir}
 	args = append(args, extraFlags...)
-	cmd := exec.Command(args[0], args[1:]...)
-	if !assert.NoError(t, err) {
-		return
-	}
+	cmd := exec.Command(binary, args...)
+	errBuffer := new(bytes.Buffer)
+	cmd.Stderr = errBuffer
+	require.NoError(t, err)
+
 	output, _ := cmd.Output()
 	var actual Issues
 	err = json.Unmarshal(output, &actual)
 	if !assert.NoError(t, err) {
+		fmt.Printf("Stderr: %s\n", errBuffer)
 		fmt.Printf("Output: %s\n", output)
 		return
 	}
@@ -78,7 +76,7 @@ func ExpectIssues(t *testing.T, linter string, source string, expected Issues, e
 		if issue.Linter == linter || linter == "" {
 			// Normalise path.
 			issue.Path = "test.go"
-			issue.Message = strings.Replace(issue.Message, w.Name(), "test.go", -1)
+			issue.Message = strings.Replace(issue.Message, testFile, "test.go", -1)
 			issue.Message = strings.Replace(issue.Message, dir, "", -1)
 			actualForLinter = append(actualForLinter, issue)
 		}
@@ -86,5 +84,17 @@ func ExpectIssues(t *testing.T, linter string, source string, expected Issues, e
 	sort.Sort(expected)
 	sort.Sort(actualForLinter)
 
-	assert.Equal(t, expected, actualForLinter)
+	if !assert.Equal(t, expected, actualForLinter) {
+		fmt.Printf("Stderr: %s\n", errBuffer)
+		fmt.Printf("Output: %s\n", output)
+	}
+}
+
+func buildBinary(t *testing.T) (string, func()) {
+	tmpdir, err := ioutil.TempDir("", "regression-test")
+	require.NoError(t, err)
+	path := filepath.Join(tmpdir, "binary")
+	cmd := exec.Command("go", "build", "-o", path, "..")
+	require.NoError(t, cmd.Run())
+	return path, func() { os.RemoveAll(tmpdir) }
 }


### PR DESCRIPTION
@alecthomas we talked about this in gitter.

I split out a couple new files, one for the running of linters, another for defining and installing linters. Flag handling and output remain in `main.go`.

I also cherry-picked some changes from support.go from #289 to get the regression tests working with the new files.