### PR TITLE
Convert absolute paths to package paths for some linters

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,6 +92,24 @@ var (
 
 	linterTakesFilesGroupedByPackage = newStringSet("vet", "vetshadow")
 
+	linterTakesPackagePaths = newStringSet(
+		"errcheck",
+		"aligncheck",
+		"errcheck",
+		"gosimple",
+		"interfacer",
+		"megacheck",
+		"safesql",
+		"staticcheck",
+		"structcheck",
+		"test",
+		"testify",
+		"unconvert",
+		"unparam",
+		"unused",
+		"varcheck",
+	)
+
 	// Linter definitions.
 	linterDefinitions = map[string]string{
 		"aligncheck":  `aligncheck:^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,

--- a/execute.go
+++ b/execute.go
@@ -14,9 +14,8 @@ import (
 	"sync"
 	"time"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/google/shlex"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
 
 type Vars map[string]string
@@ -83,7 +82,10 @@ func (l *linterState) Partitions() ([][]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	parts := l.Linter.partitionStrategy(cmdArgs, l.paths)
+	parts, err := l.Linter.partitionStrategy(cmdArgs, l.paths)
+	if err != nil {
+		return nil, err
+	}
 	if len(parts) == 0 {
 		return nil, fmt.Errorf("%s: no files to lint", l.Name)
 	}

--- a/execute_test.go
+++ b/execute_test.go
@@ -29,7 +29,7 @@ func TestSortedIssues(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestLinterStateParitions(t *testing.T) {
+func TestLinterStatePartitions(t *testing.T) {
 	noPartitions := func(_ []string, _ []string) [][]string {
 		return nil
 	}

--- a/execute_test.go
+++ b/execute_test.go
@@ -30,8 +30,8 @@ func TestSortedIssues(t *testing.T) {
 }
 
 func TestLinterStatePartitions(t *testing.T) {
-	noPartitions := func(_ []string, _ []string) [][]string {
-		return nil
+	noPartitions := func(_ []string, _ []string) ([][]string, error) {
+		return nil, nil
 	}
 
 	state := &linterState{

--- a/linters.go
+++ b/linters.go
@@ -57,7 +57,7 @@ func LinterFromName(name string) *Linter {
 		SeverityOverride:  Severity(config.Severity[name]),
 		MessageOverride:   config.MessageOverride[name],
 		regex:             re,
-		partitionStrategy: getParitionStrategy(name),
+		partitionStrategy: getPartitionStrategy(name),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -392,7 +392,7 @@ func replaceWithMegacheck(enabled []string) []string {
 }
 
 func findVendoredLinters() string {
-	gopaths := strings.Split(getGoPath(), string(os.PathListSeparator))
+	gopaths := getGoPathList()
 	for _, home := range vendoredSearchPaths {
 		for _, p := range gopaths {
 			joined := append([]string{p, "src"}, home...)
@@ -416,6 +416,10 @@ func getGoPath() string {
 	return path
 }
 
+func getGoPathList() []string {
+	return strings.Split(getGoPath(), string(os.PathListSeparator))
+}
+
 // addPath appends p to paths and returns it if:
 // 1. p is not a blank string
 // 2. p doesn't already exist in paths
@@ -434,7 +438,7 @@ func addPath(p string, paths []string) []string {
 
 // Ensure all "bin" directories from GOPATH exists in PATH, as well as GOBIN if set.
 func configureEnvironment() {
-	gopaths := strings.Split(getGoPath(), string(os.PathListSeparator))
+	gopaths := getGoPathList()
 	paths := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
 	gobin := os.Getenv("GOBIN")
 

--- a/partition.go
+++ b/partition.go
@@ -9,7 +9,7 @@ const MaxCommandBytes = 32000
 
 type partitionStrategy func([]string, []string) [][]string
 
-func getParitionStrategy(name string) partitionStrategy {
+func getPartitionStrategy(name string) partitionStrategy {
 	switch {
 	case linterTakesFiles.contains(name):
 		return partitionToMaxArgSizeWithFileGlobs
@@ -19,7 +19,7 @@ func getParitionStrategy(name string) partitionStrategy {
 	return partitionToMaxArgSize
 }
 
-func packagesToFileGlobs(paths []string) []string {
+func pathsToFileGlobs(paths []string) []string {
 	filePaths := []string{}
 	for _, dir := range paths {
 		// ignore error because the glob pattern is hardcoded
@@ -34,7 +34,7 @@ func partitionToMaxArgSize(cmdArgs []string, paths []string) [][]string {
 }
 
 func partitionToMaxSize(cmdArgs []string, paths []string, maxSize int) [][]string {
-	partitions := newSizeParitioner(cmdArgs, maxSize)
+	partitions := newSizePartitioner(cmdArgs, maxSize)
 	for _, path := range paths {
 		partitions.add(path)
 	}
@@ -49,7 +49,7 @@ type sizePartitioner struct {
 	max     int
 }
 
-func newSizeParitioner(base []string, max int) *sizePartitioner {
+func newSizePartitioner(base []string, max int) *sizePartitioner {
 	p := &sizePartitioner{base: base, max: max}
 	p.new()
 	return p
@@ -80,7 +80,7 @@ func (p *sizePartitioner) end() [][]string {
 }
 
 func partitionToMaxArgSizeWithFileGlobs(cmdArgs []string, paths []string) [][]string {
-	filePaths := packagesToFileGlobs(paths)
+	filePaths := pathsToFileGlobs(paths)
 	if len(filePaths) == 0 {
 		return nil
 	}
@@ -90,7 +90,7 @@ func partitionToMaxArgSizeWithFileGlobs(cmdArgs []string, paths []string) [][]st
 func partitionToPackageFileGlobs(cmdArgs []string, paths []string) [][]string {
 	parts := [][]string{}
 	for _, path := range paths {
-		filePaths := packagesToFileGlobs([]string{path})
+		filePaths := pathsToFileGlobs([]string{path})
 		if len(filePaths) == 0 {
 			continue
 		}

--- a/partition_test.go
+++ b/partition_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParitionToMaxSize(t *testing.T) {
+func TestPartitionToMaxSize(t *testing.T) {
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{"one", "two", "three", "four"}
 

--- a/partition_test.go
+++ b/partition_test.go
@@ -38,7 +38,8 @@ func TestPartitionToPackageFileGlobs(t *testing.T) {
 		mkGoFile(t, dir, "other.go")
 	}
 
-	parts := partitionToPackageFileGlobs(cmdArgs, paths)
+	parts, err := partitionToPackageFileGlobs(cmdArgs, paths)
+	require.NoError(t, err)
 	expected := [][]string{
 		append(cmdArgs, packagePaths(paths[0], "file.go", "other.go")...),
 		append(cmdArgs, packagePaths(paths[1], "file.go", "other.go")...),
@@ -61,7 +62,8 @@ func TestPartitionToPackageFileGlobsNoFiles(t *testing.T) {
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
-	parts := partitionToPackageFileGlobs(cmdArgs, paths)
+	parts, err := partitionToPackageFileGlobs(cmdArgs, paths)
+	require.NoError(t, err)
 	assert.Len(t, parts, 0)
 }
 
@@ -72,6 +74,26 @@ func TestPartitionToMaxArgSizeWithFileGlobsNoFiles(t *testing.T) {
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
-	parts := partitionToMaxArgSizeWithFileGlobs(cmdArgs, paths)
+	parts, err := partitionToMaxArgSizeWithFileGlobs(cmdArgs, paths)
+	require.NoError(t, err)
 	assert.Len(t, parts, 0)
+}
+
+func TestPathsToPackagePaths(t *testing.T) {
+	root := "/fake/root"
+	defer fakeGoPath(t, root)()
+
+	packagePaths, err := pathsToPackagePaths([]string{
+		filepath.Join(root, "src", "example.com", "foo"),
+		"./relative/package",
+	})
+	require.NoError(t, err)
+	expected := []string{"example.com/foo", "./relative/package"}
+	assert.Equal(t, expected, packagePaths)
+}
+
+func fakeGoPath(t *testing.T, path string) func() {
+	oldpath := os.Getenv("GOPATH")
+	require.NoError(t, os.Setenv("GOPATH", path))
+	return func() { require.NoError(t, os.Setenv("GOPATH", oldpath)) }
 }


### PR DESCRIPTION
Fixes #318

Some linters don't accept absolute paths, so convert them to package paths.