### PR TITLE
Convert default linter config from separate maps to a single map of linterConfig

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -37,18 +37,18 @@ func aggregateIssues(issues chan *Issue) chan *Issue {
 				message: issue.Message,
 			}
 			if existing, ok := issueMap[key]; ok {
-				existing.linterNames = append(existing.linterNames, issue.Linter.Name)
+				existing.linterNames = append(existing.linterNames, issue.Linter)
 			} else {
 				issueMap[key] = &multiIssue{
 					Issue:       issue,
-					linterNames: []string{issue.Linter.Name},
+					linterNames: []string{issue.Linter},
 				}
 			}
 		}
 		for _, multi := range issueMap {
 			issue := multi.Issue
 			sort.Strings(multi.linterNames)
-			issue.Linter.Name = strings.Join(multi.linterNames, ", ")
+			issue.Linter = strings.Join(multi.linterNames, ", ")
 			out <- issue
 		}
 		close(out)

--- a/checkstyle.go
+++ b/checkstyle.go
@@ -52,7 +52,7 @@ func outputToCheckstyle(issues chan *Issue) int {
 			Line:     issue.Line,
 			Message:  issue.Message,
 			Severity: string(issue.Severity),
-			Source:   issue.Linter.Name,
+			Source:   issue.Linter,
 		})
 		status = 1
 	}

--- a/config.go
+++ b/config.go
@@ -70,140 +70,40 @@ func (td *jsonDuration) Duration() time.Duration {
 	return time.Duration(*td)
 }
 
+// TODO: should be a field on Config struct
+var formatTemplate = &template.Template{}
+
+var sortKeys = []string{"none", "path", "line", "column", "severity", "message", "linter"}
+
 // Configuration defaults.
-var (
-	vetRe = `^(?:vet:.*?\.go:\s+(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*))|(?:(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*))$`
+var config = &Config{
+	Format: "{{.Path}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}})",
 
-	// TODO: should be a field on Config struct
-	formatTemplate = &template.Template{}
-	installMap     = map[string]string{
-		"aligncheck":  "github.com/opennota/check/cmd/aligncheck",
-		"deadcode":    "github.com/tsenart/deadcode",
-		"dupl":        "github.com/mibk/dupl",
-		"errcheck":    "github.com/kisielk/errcheck",
-		"gas":         "github.com/GoASTScanner/gas",
-		"goconst":     "github.com/jgautheron/goconst/cmd/goconst",
-		"gocyclo":     "github.com/alecthomas/gocyclo",
-		"goimports":   "golang.org/x/tools/cmd/goimports",
-		"golint":      "github.com/golang/lint/golint",
-		"gosimple":    "honnef.co/go/tools/cmd/gosimple",
-		"gotype":      "golang.org/x/tools/cmd/gotype",
-		"ineffassign": "github.com/gordonklaus/ineffassign",
-		"interfacer":  "github.com/mvdan/interfacer/cmd/interfacer",
-		"lll":         "github.com/walle/lll/cmd/lll",
-		"megacheck":   "honnef.co/go/tools/cmd/megacheck",
-		"misspell":    "github.com/client9/misspell/cmd/misspell",
-		"safesql":     "github.com/stripe/safesql",
-		"staticcheck": "honnef.co/go/tools/cmd/staticcheck",
-		"structcheck": "github.com/opennota/check/cmd/structcheck",
-		"unconvert":   "github.com/mdempsky/unconvert",
-		"unparam":     "github.com/mvdan/unparam",
-		"unused":      "honnef.co/go/tools/cmd/unused",
-		"varcheck":    "github.com/opennota/check/cmd/varcheck",
-	}
-	slowLinters = []string{"structcheck", "varcheck", "errcheck", "aligncheck", "testify", "test", "interfacer", "unconvert", "deadcode", "safesql", "staticcheck", "unparam", "unused", "gosimple", "megacheck"}
-	sortKeys    = []string{"none", "path", "line", "column", "severity", "message", "linter"}
-
-	linterTakesFiles = newStringSet("dupl", "gofmt", "goimports", "lll", "misspell")
-
-	linterTakesFilesGroupedByPackage = newStringSet("vet", "vetshadow")
-
-	linterTakesPackagePaths = newStringSet(
-		"errcheck",
-		"aligncheck",
-		"errcheck",
-		"gosimple",
-		"interfacer",
-		"megacheck",
-		"safesql",
-		"staticcheck",
-		"structcheck",
-		"test",
-		"testify",
-		"unconvert",
-		"unparam",
-		"unused",
-		"varcheck",
-	)
-
-	// Linter definitions.
-	linterDefinitions = map[string]string{
-		"aligncheck":  `aligncheck:^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
-		"deadcode":    `deadcode:^deadcode: (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
-		"dupl":        `dupl -plumbing -threshold {duplthreshold}:^(?P<path>.*?\.go):(?P<line>\d+)-\d+:\s*(?P<message>.*)$`,
-		"errcheck":    `errcheck -abspath:PATH:LINE:COL:MESSAGE`,
-		"gas":         `gas -fmt=csv:^(?P<path>.*?\.go),(?P<line>\d+),(?P<message>[^,]+,[^,]+,[^,]+)`,
-		"goconst":     `goconst -min-occurrences {min_occurrences} -min-length {min_const_length}:PATH:LINE:COL:MESSAGE`,
-		"gocyclo":     `gocyclo -over {mincyclo}:^(?P<cyclo>\d+)\s+\S+\s(?P<function>\S+)\s+(?P<path>.*?\.go):(?P<line>\d+):(\d+)$`,
-		"gofmt":       `gofmt -l -s:^(?P<path>.*?\.go)$`,
-		"goimports":   `goimports -l:^(?P<path>.*?\.go)$`,
-		"golint":      "golint -min_confidence {min_confidence}:PATH:LINE:COL:MESSAGE",
-		"gosimple":    "gosimple:PATH:LINE:COL:MESSAGE",
-		"gotype":      "gotype -e {tests=-t}:PATH:LINE:COL:MESSAGE",
-		"ineffassign": `ineffassign -n:PATH:LINE:COL:MESSAGE`,
-		"interfacer":  `interfacer:PATH:LINE:COL:MESSAGE`,
-		"lll":         `lll -g -l {maxlinelength}:PATH:LINE:MESSAGE`,
-		"megacheck":   "megacheck:PATH:LINE:COL:MESSAGE",
-		"misspell":    "misspell -j 1:PATH:LINE:COL:MESSAGE",
-		"safesql":     `safesql:^- (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+)$`,
-		"staticcheck": "staticcheck:PATH:LINE:COL:MESSAGE",
-		"structcheck": `structcheck {tests=-t}:^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
-		"test":        `go test:^--- FAIL: .*$\s+(?P<path>.*?\.go):(?P<line>\d+): (?P<message>.*)$`,
-		"testify":     `go test:Location:\s+(?P<path>.*?\.go):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)`,
-		"unconvert":   "unconvert:PATH:LINE:COL:MESSAGE",
-		"unparam":     `unparam:PATH:LINE:COL:MESSAGE`,
-		"unused":      `unused:PATH:LINE:COL:MESSAGE`,
-		"varcheck":    `varcheck:^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
-		"vet":         `go tool vet:` + vetRe,
-		"vetshadow":   `go tool vet --shadow:` + vetRe,
-	}
-
-	config = &Config{
-		Format: "{{.Path}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}})",
-
-		Severity: map[string]string{
-			"gotype":  "error",
-			"test":    "error",
-			"testify": "error",
-			"vet":     "error",
-		},
-		MessageOverride: map[string]string{
-			"errcheck":    "error return value not checked ({message})",
-			"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
-			"gofmt":       "file is not gofmted with -s",
-			"goimports":   "file is not goimported",
-			"safesql":     "potentially unsafe SQL statement",
-			"structcheck": "unused struct field {message}",
-			"unparam":     "parameter {message}",
-			"varcheck":    "unused variable or constant {message}",
-		},
-		Enable: []string{
-			"aligncheck",
-			"deadcode",
-			"errcheck",
-			"gas",
-			"goconst",
-			"gocyclo",
-			"golint",
-			"gotype",
-			"ineffassign",
-			"interfacer",
-			"megacheck",
-			"structcheck",
-			"unconvert",
-			"varcheck",
-			"vet",
-			"vetshadow",
-		},
-		VendoredLinters: true,
-		Concurrency:     runtime.NumCPU(),
-		Cyclo:           10,
-		LineLength:      80,
-		MinConfidence:   0.8,
-		MinOccurrences:  3,
-		MinConstLength:  3,
-		DuplThreshold:   50,
-		Sort:            []string{"none"},
-		Deadline:        jsonDuration(time.Second * 30),
-	}
-)
+	Severity: map[string]string{
+		"gotype":  "error",
+		"test":    "error",
+		"testify": "error",
+		"vet":     "error",
+	},
+	MessageOverride: map[string]string{
+		"errcheck":    "error return value not checked ({message})",
+		"gocyclo":     "cyclomatic complexity {cyclo} of function {function}() is high (> {mincyclo})",
+		"gofmt":       "file is not gofmted with -s",
+		"goimports":   "file is not goimported",
+		"safesql":     "potentially unsafe SQL statement",
+		"structcheck": "unused struct field {message}",
+		"unparam":     "parameter {message}",
+		"varcheck":    "unused variable or constant {message}",
+	},
+	Enable:          defaultEnabled(),
+	VendoredLinters: true,
+	Concurrency:     runtime.NumCPU(),
+	Cyclo:           10,
+	LineLength:      80,
+	MinConfidence:   0.8,
+	MinOccurrences:  3,
+	MinConstLength:  3,
+	DuplThreshold:   50,
+	Sort:            []string{"none"},
+	Deadline:        jsonDuration(time.Second * 30),
+}

--- a/directives.go
+++ b/directives.go
@@ -24,7 +24,7 @@ func (i *ignoredRange) matches(issue *Issue) bool {
 		return true
 	}
 	for _, l := range i.linters {
-		if l == issue.Linter.Name {
+		if l == issue.Linter {
 			return true
 		}
 	}

--- a/execute.go
+++ b/execute.go
@@ -82,7 +82,7 @@ func (l *linterState) Partitions() ([][]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	parts, err := l.Linter.partitionStrategy(cmdArgs, l.paths)
+	parts, err := l.Linter.PartitionStrategy(cmdArgs, l.paths)
 	if err != nil {
 		return nil, err
 	}
@@ -268,6 +268,8 @@ func processOutput(state *linterState, out []byte) {
 			case "":
 			}
 		}
+		// TODO: set messageOveride and severity on the Linter instead of reading
+		// them directly from the static config
 		if m, ok := config.MessageOverride[state.Name]; ok {
 			issue.Message = vars.Replace(m)
 		}
@@ -284,7 +286,6 @@ func processOutput(state *linterState, out []byte) {
 		}
 		state.issues <- issue
 	}
-	return
 }
 
 func relativePath(root, path string) string {

--- a/execute.go
+++ b/execute.go
@@ -51,7 +51,7 @@ const ( // nolint: deadcode
 )
 
 type Issue struct {
-	Linter   *Linter  `json:"linter"`
+	Linter   string   `json:"linter"`
 	Severity Severity `json:"severity"`
 	Path     string   `json:"path"`
 	Line     int      `json:"line"`
@@ -239,7 +239,7 @@ func processOutput(state *linterState, out []byte) {
 			group = append(group, fragment)
 		}
 
-		issue := &Issue{Line: 1, Linter: state.Linter}
+		issue := &Issue{Line: 1, Linter: state.Linter.Name}
 		for i, name := range re.SubexpNames() {
 			if group[i] == nil {
 				continue
@@ -352,7 +352,7 @@ func (s *sortedIssues) Less(i, j int) bool {
 				return false
 			}
 		case "linter":
-			if l.Linter.Name > r.Linter.Name {
+			if l.Linter > r.Linter {
 				return false
 			}
 		}

--- a/linters.go
+++ b/linters.go
@@ -17,7 +17,7 @@ type LinterConfig struct {
 	Pattern           string
 	InstallFrom       string
 	PartitionStrategy partitionStrategy
-	IsSlow            bool
+	IsFast            bool
 	defaultEnabled    bool
 }
 
@@ -175,7 +175,6 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
 		InstallFrom:       "github.com/opennota/check/cmd/aligncheck",
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
-		IsSlow:            true,
 		defaultEnabled:    true,
 	},
 	"deadcode": {
@@ -184,7 +183,6 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `^deadcode: (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
 		InstallFrom:       "github.com/tsenart/deadcode",
 		PartitionStrategy: partitionToMaxArgSize,
-		IsSlow:            true,
 		defaultEnabled:    true,
 	},
 	"dupl": {
@@ -193,13 +191,13 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `^(?P<path>.*?\.go):(?P<line>\d+)-\d+:\s*(?P<message>.*)$`,
 		InstallFrom:       "github.com/mibk/dupl",
 		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+		IsFast:            true,
 	},
 	"errcheck": {
 		Name:              "errcheck",
 		Command:           `errcheck -abspath`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/kisielk/errcheck",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -210,6 +208,7 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/GoASTScanner/gas",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"goconst": {
 		Name:              "goconst",
@@ -218,6 +217,7 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/jgautheron/goconst/cmd/goconst",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"gocyclo": {
 		Name:              "gocyclo",
@@ -226,12 +226,14 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/alecthomas/gocyclo",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"gofmt": {
 		Name:              "gofmt",
 		Command:           `gofmt -l -s`,
 		Pattern:           `^(?P<path>.*?\.go)$`,
 		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+		IsFast:            true,
 	},
 	"goimports": {
 		Name:              "goimports",
@@ -239,6 +241,7 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `^(?P<path>.*?\.go)$`,
 		InstallFrom:       "golang.org/x/tools/cmd/goimports",
 		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+		IsFast:            true,
 	},
 	"golint": {
 		Name:              "golint",
@@ -247,13 +250,13 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/golang/lint/golint",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"gosimple": {
 		Name:              "gosimple",
 		Command:           `gosimple`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "honnef.co/go/tools/cmd/gosimple",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"gotype": {
@@ -263,6 +266,7 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "golang.org/x/tools/cmd/gotype",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"ineffassign": {
 		Name:              "ineffassign",
@@ -271,13 +275,13 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/gordonklaus/ineffassign",
 		PartitionStrategy: partitionToMaxArgSize,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"interfacer": {
 		Name:              "interfacer",
 		Command:           `interfacer`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/mvdan/interfacer/cmd/interfacer",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -287,13 +291,13 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `PATH:LINE:MESSAGE`,
 		InstallFrom:       "github.com/walle/lll/cmd/lll",
 		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+		IsFast:            true,
 	},
 	"megacheck": {
 		Name:              "megacheck",
 		Command:           `megacheck`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "honnef.co/go/tools/cmd/megacheck",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -303,13 +307,13 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/client9/misspell/cmd/misspell",
 		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+		IsFast:            true,
 	},
 	"safesql": {
 		Name:              "safesql",
 		Command:           `safesql`,
 		Pattern:           `^- (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+)$`,
 		InstallFrom:       "github.com/stripe/safesql",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"staticcheck": {
@@ -317,7 +321,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `staticcheck`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "honnef.co/go/tools/cmd/staticcheck",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"structcheck": {
@@ -325,7 +328,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `structcheck {tests=-t}`,
 		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
 		InstallFrom:       "github.com/opennota/check/cmd/structcheck",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -333,14 +335,12 @@ var defaultLinters = map[string]LinterConfig{
 		Name:              "test",
 		Command:           `go test`,
 		Pattern:           `^--- FAIL: .*$\s+(?P<path>.*?\.go):(?P<line>\d+): (?P<message>.*)$`,
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"testify": {
 		Name:              "testify",
 		Command:           `go test`,
 		Pattern:           `Location:\s+(?P<path>.*?\.go):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)`,
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"unconvert": {
@@ -348,7 +348,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `unconvert`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/mdempsky/unconvert",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -357,7 +356,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `unparam`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/mvdan/unparam",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"unused": {
@@ -365,7 +363,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `unused`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "honnef.co/go/tools/cmd/unused",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 	},
 	"varcheck": {
@@ -373,7 +370,6 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `varcheck`,
 		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
 		InstallFrom:       "github.com/opennota/check/cmd/varcheck",
-		IsSlow:            true,
 		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
 		defaultEnabled:    true,
 	},
@@ -383,6 +379,7 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           vetPattern,
 		PartitionStrategy: partitionToPackageFileGlobs,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 	"vetshadow": {
 		Name:              "vetshadow",
@@ -390,5 +387,6 @@ var defaultLinters = map[string]LinterConfig{
 		Pattern:           vetPattern,
 		PartitionStrategy: partitionToPackageFileGlobs,
 		defaultEnabled:    true,
+		IsFast:            true,
 	},
 }

--- a/linters.go
+++ b/linters.go
@@ -5,21 +5,40 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
 
-type Linter struct {
-	Name             string
-	Command          string
-	Pattern          string
-	InstallFrom      string
-	SeverityOverride Severity
-	MessageOverride  string
+type LinterConfig struct {
+	Name              string
+	Command           string
+	Pattern           string
+	InstallFrom       string
+	PartitionStrategy partitionStrategy
+	IsSlow            bool
+	defaultEnabled    bool
+}
 
-	regex             *regexp.Regexp
-	partitionStrategy partitionStrategy
+type Linter struct {
+	LinterConfig
+	regex *regexp.Regexp
+}
+
+// NewLinter returns a new linter from a config
+func NewLinter(config LinterConfig) (*Linter, error) {
+	if p, ok := predefinedPatterns[config.Pattern]; ok {
+		config.Pattern = p
+	}
+	regex, err := regexp.Compile("(?m:" + config.Pattern + ")")
+	if err != nil {
+		return nil, err
+	}
+	return &Linter{
+		LinterConfig: config,
+		regex:        regex,
+	}, nil
 }
 
 func (l *Linter) String() string {
@@ -31,29 +50,26 @@ var predefinedPatterns = map[string]string{
 	"PATH:LINE:MESSAGE":     `^(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*)$`,
 }
 
-func LinterFromName(name string) *Linter {
-	s := linterDefinitions[name]
-	parts := strings.SplitN(s, ":", 2)
+func getLinterByName(name string, customSpec string) *Linter {
+	if customSpec != "" {
+		return parseLinterSpec(name, customSpec)
+	}
+	linter, _ := NewLinter(defaultLinters[name])
+	return linter
+}
+
+func parseLinterSpec(name string, spec string) *Linter {
+	parts := strings.SplitN(spec, ":", 2)
 	if len(parts) < 2 {
-		kingpin.Fatalf("invalid linter: %q", name)
+		kingpin.Fatalf("invalid linter: %q", spec)
 	}
 
-	pattern := parts[1]
-	if p, ok := predefinedPatterns[pattern]; ok {
-		pattern = p
-	}
-	re, err := regexp.Compile("(?m:" + pattern + ")")
-	kingpin.FatalIfError(err, "invalid regex for %q", name)
-	return &Linter{
-		Name:              name,
-		Command:           s[0:strings.Index(s, ":")],
-		Pattern:           pattern,
-		InstallFrom:       installMap[name],
-		SeverityOverride:  Severity(config.Severity[name]),
-		MessageOverride:   config.MessageOverride[name],
-		regex:             re,
-		partitionStrategy: getPartitionStrategy(name),
-	}
+	config := defaultLinters[name]
+	config.Command, config.Pattern = parts[0], parts[1]
+
+	linter, err := NewLinter(config)
+	kingpin.FatalIfError(err, "invalid linter %q", name)
+	return linter
 }
 
 func makeInstallCommand(linters ...string) []string {
@@ -106,12 +122,16 @@ func installLintersIndividually(targets []string) {
 }
 
 func installLinters() {
-	names := make([]string, 0, len(installMap))
-	targets := make([]string, 0, len(installMap))
-	for name, target := range installMap {
+	names := make([]string, 0, len(defaultLinters))
+	targets := make([]string, 0, len(defaultLinters))
+	for name, config := range defaultLinters {
+		if config.InstallFrom == "" {
+			continue
+		}
 		names = append(names, name)
-		targets = append(targets, target)
+		targets = append(targets, config.InstallFrom)
 	}
+	sort.Strings(names)
 	namesStr := strings.Join(names, "\n  ")
 	if config.DownloadOnly {
 		fmt.Printf("Downloading:\n  %s\n", namesStr)
@@ -124,4 +144,251 @@ func installLinters() {
 	}
 	warning("failed to install one or more linters: %s (installing individually)", err)
 	installLintersIndividually(targets)
+}
+
+func getDefaultLinters() []*Linter {
+	out := []*Linter{}
+	for _, config := range defaultLinters {
+		linter, err := NewLinter(config)
+		kingpin.FatalIfError(err, "invalid linter %q", config.Name)
+		out = append(out, linter)
+	}
+	return out
+}
+
+func defaultEnabled() []string {
+	enabled := []string{}
+	for name, config := range defaultLinters {
+		if config.defaultEnabled {
+			enabled = append(enabled, name)
+		}
+	}
+	return enabled
+}
+
+const vetPattern = `^(?:vet:.*?\.go:\s+(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*))|(?:(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*))$`
+
+var defaultLinters = map[string]LinterConfig{
+	"aligncheck": {
+		Name:              "aligncheck",
+		Command:           "aligncheck",
+		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
+		InstallFrom:       "github.com/opennota/check/cmd/aligncheck",
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		IsSlow:            true,
+		defaultEnabled:    true,
+	},
+	"deadcode": {
+		Name:              "deadcode",
+		Command:           "deadcode",
+		Pattern:           `^deadcode: (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
+		InstallFrom:       "github.com/tsenart/deadcode",
+		PartitionStrategy: partitionToMaxArgSize,
+		IsSlow:            true,
+		defaultEnabled:    true,
+	},
+	"dupl": {
+		Name:              "dupl",
+		Command:           `dupl -plumbing -threshold {duplthreshold}`,
+		Pattern:           `^(?P<path>.*?\.go):(?P<line>\d+)-\d+:\s*(?P<message>.*)$`,
+		InstallFrom:       "github.com/mibk/dupl",
+		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+	},
+	"errcheck": {
+		Name:              "errcheck",
+		Command:           `errcheck -abspath`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/kisielk/errcheck",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"gas": {
+		Name:              "gas",
+		Command:           `gas -fmt=csv`,
+		Pattern:           `^(?P<path>.*?\.go),(?P<line>\d+),(?P<message>[^,]+,[^,]+,[^,]+)`,
+		InstallFrom:       "github.com/GoASTScanner/gas",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"goconst": {
+		Name:              "goconst",
+		Command:           `goconst -min-occurrences {min_occurrences} -min-length {min_const_length}`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/jgautheron/goconst/cmd/goconst",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"gocyclo": {
+		Name:              "gocyclo",
+		Command:           `gocyclo -over {mincyclo}`,
+		Pattern:           `^(?P<cyclo>\d+)\s+\S+\s(?P<function>\S+)\s+(?P<path>.*?\.go):(?P<line>\d+):(\d+)$`,
+		InstallFrom:       "github.com/alecthomas/gocyclo",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"gofmt": {
+		Name:              "gofmt",
+		Command:           `gofmt -l -s`,
+		Pattern:           `^(?P<path>.*?\.go)$`,
+		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+	},
+	"goimports": {
+		Name:              "goimports",
+		Command:           `goimports -l`,
+		Pattern:           `^(?P<path>.*?\.go)$`,
+		InstallFrom:       "golang.org/x/tools/cmd/goimports",
+		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+	},
+	"golint": {
+		Name:              "golint",
+		Command:           `golint -min_confidence {min_confidence}`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/golang/lint/golint",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"gosimple": {
+		Name:              "gosimple",
+		Command:           `gosimple`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "honnef.co/go/tools/cmd/gosimple",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"gotype": {
+		Name:              "gotype",
+		Command:           `gotype -e {tests=-t}`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "golang.org/x/tools/cmd/gotype",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"ineffassign": {
+		Name:              "ineffassign",
+		Command:           `ineffassign -n`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/gordonklaus/ineffassign",
+		PartitionStrategy: partitionToMaxArgSize,
+		defaultEnabled:    true,
+	},
+	"interfacer": {
+		Name:              "interfacer",
+		Command:           `interfacer`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/mvdan/interfacer/cmd/interfacer",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"lll": {
+		Name:              "lll",
+		Command:           `lll -g -l {maxlinelength}`,
+		Pattern:           `PATH:LINE:MESSAGE`,
+		InstallFrom:       "github.com/walle/lll/cmd/lll",
+		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+	},
+	"megacheck": {
+		Name:              "megacheck",
+		Command:           `megacheck`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "honnef.co/go/tools/cmd/megacheck",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"misspell": {
+		Name:              "misspell",
+		Command:           `misspell -j 1`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/client9/misspell/cmd/misspell",
+		PartitionStrategy: partitionToMaxArgSizeWithFileGlobs,
+	},
+	"safesql": {
+		Name:              "safesql",
+		Command:           `safesql`,
+		Pattern:           `^- (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+)$`,
+		InstallFrom:       "github.com/stripe/safesql",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"staticcheck": {
+		Name:              "staticcheck",
+		Command:           `staticcheck`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "honnef.co/go/tools/cmd/staticcheck",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"structcheck": {
+		Name:              "structcheck",
+		Command:           `structcheck {tests=-t}`,
+		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)$`,
+		InstallFrom:       "github.com/opennota/check/cmd/structcheck",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"test": {
+		Name:              "test",
+		Command:           `go test`,
+		Pattern:           `^--- FAIL: .*$\s+(?P<path>.*?\.go):(?P<line>\d+): (?P<message>.*)$`,
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"testify": {
+		Name:              "testify",
+		Command:           `go test`,
+		Pattern:           `Location:\s+(?P<path>.*?\.go):(?P<line>\d+)$\s+Error:\s+(?P<message>[^\n]+)`,
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"unconvert": {
+		Name:              "unconvert",
+		Command:           `unconvert`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/mdempsky/unconvert",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"unparam": {
+		Name:              "unparam",
+		Command:           `unparam`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/mvdan/unparam",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"unused": {
+		Name:              "unused",
+		Command:           `unused`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "honnef.co/go/tools/cmd/unused",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+	},
+	"varcheck": {
+		Name:              "varcheck",
+		Command:           `varcheck`,
+		Pattern:           `^(?:[^:]+: )?(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$`,
+		InstallFrom:       "github.com/opennota/check/cmd/varcheck",
+		IsSlow:            true,
+		PartitionStrategy: partitionToMaxArgSizeWithPackagePaths,
+		defaultEnabled:    true,
+	},
+	"vet": {
+		Name:              "vet",
+		Command:           `go tool vet`,
+		Pattern:           vetPattern,
+		PartitionStrategy: partitionToPackageFileGlobs,
+		defaultEnabled:    true,
+	},
+	"vetshadow": {
+		Name:              "vetshadow",
+		Command:           `go tool vet --shadow`,
+		Pattern:           vetPattern,
+		PartitionStrategy: partitionToPackageFileGlobs,
+		defaultEnabled:    true,
+	},
 }

--- a/linters.go
+++ b/linters.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,19 +11,15 @@ import (
 )
 
 type Linter struct {
-	Name             string   `json:"name"`
-	Command          string   `json:"command"`
-	Pattern          string   `json:"pattern"`
-	InstallFrom      string   `json:"install_from"`
-	SeverityOverride Severity `json:"severity,omitempty"`
-	MessageOverride  string   `json:"message_override,omitempty"`
+	Name             string
+	Command          string
+	Pattern          string
+	InstallFrom      string
+	SeverityOverride Severity
+	MessageOverride  string
 
 	regex             *regexp.Regexp
 	partitionStrategy partitionStrategy
-}
-
-func (l *Linter) MarshalJSON() ([]byte, error) {
-	return json.Marshal(l.Name)
 }
 
 func (l *Linter) String() string {

--- a/main.go
+++ b/main.go
@@ -342,7 +342,7 @@ func lintersFromConfig(config *Config) map[string]*Linter {
 	for _, name := range config.Enable {
 		linter := getLinterByName(name, config.Linters[name])
 
-		if config.Fast && linter.IsSlow {
+		if config.Fast && !linter.IsFast {
 			continue
 		}
 		out[name] = linter

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func disableAllAction(app *kingpin.Application, element *kingpin.ParseElement, c
 }
 
 func enableAllAction(app *kingpin.Application, element *kingpin.ParseElement, ctx *kingpin.ParseContext) error {
-	for linter := range linterDefinitions {
+	for linter := range defaultLinters {
 		config.Enable = append(config.Enable, linter)
 	}
 	config.EnableAll = true
@@ -126,13 +126,13 @@ func warning(format string, args ...interface{}) {
 
 func formatLinters() string {
 	w := bytes.NewBuffer(nil)
-	for name := range linterDefinitions {
-		linter := LinterFromName(name)
+	for _, linter := range getDefaultLinters() {
 		install := "(" + linter.InstallFrom + ")"
 		if install == "()" {
 			install = ""
 		}
-		fmt.Fprintf(w, "  %s  %s\n        %s\n        %s\n", name, install, linter.Command, linter.Pattern)
+		fmt.Fprintf(w, "  %s  %s\n        %s\n        %s\n",
+			linter.Name, install, linter.Command, linter.Pattern)
 	}
 	return w.String()
 }
@@ -175,9 +175,9 @@ Severity override map (default is "warning"):
 	start := time.Now()
 	paths := resolvePaths(*pathsArg, config.Skip)
 
-	linters := lintersFromFlags()
-	status := 0
+	linters := lintersFromConfig(config)
 	issues, errch := runLinters(linters, paths, config.Concurrency, exclude, include)
+	status := 0
 	if config.JSON {
 		status |= outputToJSON(issues)
 	} else if config.Checkstyle {
@@ -196,11 +196,6 @@ Severity override map (default is "warning"):
 
 // nolint: gocyclo
 func processConfig(config *Config) (include *regexp.Regexp, exclude *regexp.Regexp) {
-	// Move configured linters into linterDefinitions.
-	for name, definition := range config.Linters {
-		linterDefinitions[name] = definition
-	}
-
 	tmpl, err := template.New("output").Parse(config.Format)
 	kingpin.FatalIfError(err, "invalid format %q", config.Format)
 	formatTemplate = tmpl
@@ -341,19 +336,19 @@ func relativePackagePath(dir string) string {
 	return "./" + dir
 }
 
-func lintersFromFlags() map[string]*Linter {
+func lintersFromConfig(config *Config) map[string]*Linter {
 	out := map[string]*Linter{}
-	config.Enable = replaceWithMegacheck(config.Enable)
-	for _, linter := range config.Enable {
-		out[linter] = LinterFromName(linter)
+	config.Enable = replaceWithMegacheck(config.Enable, config.EnableAll)
+	for _, name := range config.Enable {
+		linter := getLinterByName(name, config.Linters[name])
+
+		if config.Fast && linter.IsSlow {
+			continue
+		}
+		out[name] = linter
 	}
 	for _, linter := range config.Disable {
 		delete(out, linter)
-	}
-	if config.Fast {
-		for _, linter := range slowLinters {
-			delete(out, linter)
-		}
 	}
 	return out
 }
@@ -362,7 +357,7 @@ func lintersFromFlags() map[string]*Linter {
 // returns a either a revised list removing those and adding megacheck or an
 // unchanged slice. Emits a warning if linters were removed and swapped with
 // megacheck.
-func replaceWithMegacheck(enabled []string) []string {
+func replaceWithMegacheck(enabled []string, enableAll bool) []string {
 	var (
 		staticcheck,
 		gosimple,
@@ -384,7 +379,7 @@ func replaceWithMegacheck(enabled []string) []string {
 		}
 	}
 	if staticcheck && gosimple && unused {
-		if !config.EnableAll {
+		if !enableAll {
 			warning("staticcheck, gosimple and unused are all set, using megacheck instead")
 		}
 		return append(revised, "megacheck")

--- a/partition.go
+++ b/partition.go
@@ -10,18 +10,6 @@ const MaxCommandBytes = 32000
 
 type partitionStrategy func([]string, []string) ([][]string, error)
 
-func getPartitionStrategy(name string) partitionStrategy {
-	switch {
-	case linterTakesFiles.contains(name):
-		return partitionToMaxArgSizeWithFileGlobs
-	case linterTakesFilesGroupedByPackage.contains(name):
-		return partitionToPackageFileGlobs
-	case linterTakesPackagePaths.contains(name):
-		return partitionToMaxArgSizeWithPackagePaths
-	}
-	return partitionToMaxArgSize
-}
-
 func pathsToFileGlobs(paths []string) ([]string, error) {
 	filePaths := []string{}
 	for _, dir := range paths {

--- a/stringset.go
+++ b/stringset.go
@@ -16,11 +16,6 @@ func (s *stringSet) add(item string) {
 	s.items[item] = struct{}{}
 }
 
-func (s *stringSet) contains(item string) bool {
-	_, exists := s.items[item]
-	return exists
-}
-
 func (s *stringSet) asSlice() []string {
 	items := []string{}
 	for item := range s.items {


### PR DESCRIPTION
With this change it should be easier to see the properties of a specific linter. 

I think this change will enable us to support a full linter definition from the config format. Instead of just a list of strings in the form of `name: spec`, we could support a list of boths strings and `LinterConfig` objects. That would allow a user to fully customize a linter, including setting the partition strategy.

If we read the config during `--install` it would also let them set an `InstallFrom`.