### PR TITLE
fixup! gotype uses the `-t` flag to enable linting of test files

### DIFF
--- a/config.go
+++ b/config.go
@@ -139,7 +139,7 @@ var (
 		"goimports":   `goimports -l:^(?P<path>.*?\.go)$`,
 		"golint":      "golint -min_confidence {min_confidence}:PATH:LINE:COL:MESSAGE",
 		"gosimple":    "gosimple:PATH:LINE:COL:MESSAGE",
-		"gotype":      "gotype -e {tests=-a}:PATH:LINE:COL:MESSAGE",
+		"gotype":      "gotype -e {tests=-t}:PATH:LINE:COL:MESSAGE",
 		"ineffassign": `ineffassign -n:PATH:LINE:COL:MESSAGE`,
 		"interfacer":  `interfacer:PATH:LINE:COL:MESSAGE`,
 		"lll":         `lll -g -l {maxlinelength}:PATH:LINE:MESSAGE`,


### PR DESCRIPTION
invoked: `gometalinter --vendor --tests --fast --deadline\=5s --checkstyle -d .`

```
[...]
DEBUG: executing /home/cblades/go/bin/gotype -e -a .
DEBUG: warning: /home/cblades/go/bin/gotype returned exit status 2: flag provided but not defined: -a
usage: gotype [flags] [path ...]

The gotype command, like the front-end of a Go compiler, parses and
type-checks a single Go package. Errors are reported if the analysis
fails; otherwise gotype is quiet (unless -v is set).

Without a list of paths, gotype reads from standard input, which
must provide a single Go source file defining a complete package.

With a single directory argument, gotype checks the Go files in
that directory, comprising a single package. Use -t to include the
(in-package) _test.go files. Use -x to type check only external
test files.

Otherwise, each path must be the filename of a Go file belonging
to the same package.

Imports are processed by importing directly from the source of
imported packages (default), or by importing from compiled and
installed packages (by setting -c to the respective compiler).

The -c flag must be set to a compiler ("gc", "gccgo") when type-
checking packages containing imports with relative import paths
(import "./mypkg") because the source importer cannot know which
files to include for such packages.

  -ast
        print AST (forces -seq)
  -c string
        compiler used for installed packages (gc, gccgo, or source) (default "gc")
  -comments
        parse comments (ignored unless -ast or -trace is provided)
  -e    report all errors, not just the first 10
  -t    include in-package test files in a directory
  -trace
        print parse trace (forces -seq)
  -v    verbose mode
  -x    consider only external test files in a directory
```