### PR TITLE
Set a default partition strategy for custom linters.

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -35,6 +35,9 @@ func NewLinter(config LinterConfig) (*Linter, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.PartitionStrategy == nil {
+		config.PartitionStrategy = partitionToMaxArgSize
+	}
 	return &Linter{
 		LinterConfig: config,
 		regex:        regex,
@@ -66,6 +69,7 @@ func parseLinterSpec(name string, spec string) *Linter {
 
 	config := defaultLinters[name]
 	config.Command, config.Pattern = parts[0], parts[1]
+	config.Name = name
 
 	linter, err := NewLinter(config)
 	kingpin.FatalIfError(err, "invalid linter %q", name)

--- a/linters_test.go
+++ b/linters_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLinterWithCustomLinter(t *testing.T) {
+	config := LinterConfig{
+		Command: "/usr/bin/custom",
+		Pattern: "path",
+	}
+	linter, err := NewLinter(config)
+	require.NoError(t, err)
+	assert.NotNil(t, linter.LinterConfig.PartitionStrategy)
+}


### PR DESCRIPTION
Fixes #332 

Apparently golang doesn't let you compare functions so testing for NotNil was the best I could find.