### PR TITLE
Ability to override command/pattern individually per linter

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ func (c *StringOrLinterConfig) UnmarshalJSON(raw []byte) error {
 	if err := json.Unmarshal(raw, &linterSpec); err != nil {
 		return err
 	}
-	linter, err := parseLinterSpec("", linterSpec)
+	linter, err := parseLinterConfigSpec("", linterSpec)
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -12,9 +12,7 @@ type Config struct { // nolint: aligncheck
 	// A map from linter name -> <LinterConfig|string>.
 	//
 	// For backwards compatibility, the value stored in the JSON blob can also
-	// be a string of the form "<command>:<pattern>", <command> should always
-	// include {path} as the target directory to execute. Globs in <command>
-	// are expanded by gometalinter (not by the shell).
+	// be a string of the form "<command>:<pattern>".
 	Linters map[string]StringOrLinterConfig
 
 	// The set of linters that should be enabled.

--- a/config.go
+++ b/config.go
@@ -15,6 +15,11 @@ type Config struct { // nolint: aligncheck
 	// are expanded by gometalinter (not by the shell).
 	Linters map[string]string
 
+	// A map of linter name to a `LinterOverrideConfig` struct.
+	// NB: If a linter configuration is specified in both `Linters` and `LinterOverride`, the former
+	// is given precedence.
+	LinterOverrides map[string]LinterOverrideConfig
+
 	// The set of linters that should be enabled.
 	Enable  []string
 	Disable []string

--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ func (c *StringOrLinterConfig) UnmarshalJSON(raw []byte) error {
 	// i.e. bytes didn't represent the struct, treat them as a string
 	var linterSpec string
 	if err := json.Unmarshal(raw, &linterSpec); err != nil {
-		return nil
+		return err
 	}
 	linter, err := parseLinterSpec("", linterSpec)
 	if err != nil {

--- a/linters.go
+++ b/linters.go
@@ -21,6 +21,14 @@ type LinterConfig struct {
 	defaultEnabled    bool
 }
 
+// LinterOverrideConfig allows users to override parts of linter configuration without requiring them
+// to override the whole thing. E.g. it permits users the ability to specify just the command override
+// for a linter.
+type LinterOverrideConfig struct {
+	Command *string
+	Pattern *string
+}
+
 type Linter struct {
 	LinterConfig
 	regex *regexp.Regexp
@@ -58,6 +66,20 @@ func getLinterByName(name string, customSpec string) *Linter {
 		return parseLinterSpec(name, customSpec)
 	}
 	linter, _ := NewLinter(defaultLinters[name])
+	return linter
+}
+
+func getLinterByOverride(name string, override LinterOverrideConfig) *Linter {
+	config := defaultLinters[name]
+	config.Name = name
+	if c := override.Command; c != nil {
+		config.Command = *c
+	}
+	if p := override.Pattern; p != nil {
+		config.Pattern = *p
+	}
+	linter, err := NewLinter(config)
+	kingpin.FatalIfError(err, "invalid linter %q", name)
 	return linter
 }
 

--- a/linters.go
+++ b/linters.go
@@ -65,10 +65,10 @@ func getLinterByName(name string, overrideConf LinterConfig) *Linter {
 	return linter
 }
 
-func parseLinterSpec(name string, spec string) (LinterConfig, error) {
+func parseLinterConfigSpec(name string, spec string) (LinterConfig, error) {
 	parts := strings.SplitN(spec, ":", 2)
 	if len(parts) < 2 {
-		return LinterConfig{}, fmt.Errorf("command spec needs at least two components")
+		return LinterConfig{}, fmt.Errorf("linter spec needs at least two components")
 	}
 
 	config := defaultLinters[name]

--- a/linters_test.go
+++ b/linters_test.go
@@ -16,3 +16,13 @@ func TestNewLinterWithCustomLinter(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, linter.LinterConfig.PartitionStrategy)
 }
+
+func TestGetLinterByName(t *testing.T) {
+	config := LinterConfig{
+		Command: "aligncheck",
+		Pattern: "path",
+	}
+	overrideConfig := getLinterByName(config.Command, config)
+	require.Equal(t, config.Command, overrideConfig.Command)
+	require.Equal(t, config.Pattern, overrideConfig.Pattern)
+}

--- a/linters_test.go
+++ b/linters_test.go
@@ -16,13 +16,3 @@ func TestNewLinterWithCustomLinter(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, linter.LinterConfig.PartitionStrategy)
 }
-
-func TestLinterWithOverrideCommand(t *testing.T) {
-	command := "gosimple --with --args"
-	override := LinterOverrideConfig{
-		Command: &command,
-	}
-	linter := getLinterByOverride("gosimple", override)
-	assert.NotNil(t, linter)
-	require.Equal(t, command, linter.Command)
-}

--- a/linters_test.go
+++ b/linters_test.go
@@ -16,3 +16,13 @@ func TestNewLinterWithCustomLinter(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, linter.LinterConfig.PartitionStrategy)
 }
+
+func TestLinterWithOverrideCommand(t *testing.T) {
+	command := "gosimple --with --args"
+	override := LinterOverrideConfig{
+		Command: &command,
+	}
+	linter := getLinterByOverride("gosimple", override)
+	assert.NotNil(t, linter)
+	require.Equal(t, command, linter.Command)
+}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func setupFlags(app *kingpin.Application) {
 	app.Flag("config", "Load JSON configuration from file.").Action(loadConfig).String()
 	app.Flag("disable", "Disable previously enabled linters.").PlaceHolder("LINTER").Short('D').Action(disableAction).Strings()
 	app.Flag("enable", "Enable previously disabled linters.").PlaceHolder("LINTER").Short('E').Action(enableAction).Strings()
-	app.Flag("linter", "Define a linter.").PlaceHolder("NAME:COMMAND:PATTERN").StringMapVar(&config.Linters)
+	app.Flag("linter", "Define a linter.").PlaceHolder("NAME:COMMAND:PATTERN").Action(cliLinterOverrides).StringMap()
 	app.Flag("message-overrides", "Override message from linter. {message} will be expanded to the original message.").PlaceHolder("LINTER:MESSAGE").StringMapVar(&config.MessageOverride)
 	app.Flag("severity", "Map of linter severities.").PlaceHolder("LINTER:SEVERITY").StringMapVar(&config.Severity)
 	app.Flag("disable-all", "Disable all linters.").Action(disableAllAction).Bool()
@@ -62,6 +62,22 @@ func setupFlags(app *kingpin.Application) {
 	app.Flag("enable-gc", "Enable GC for linters (useful on large repositories).").BoolVar(&config.EnableGC)
 	app.Flag("aggregate", "Aggregate issues reported by several linters.").BoolVar(&config.Aggregate)
 	app.GetFlag("help").Short('h')
+}
+
+func cliLinterOverrides(app *kingpin.Application, element *kingpin.ParseElement, ctx *kingpin.ParseContext) error {
+	// expected input structure - <name>:<command-spec>
+	parts := strings.SplitN(*element.Value, ":", 2)
+	if len(parts) < 2 {
+		return fmt.Errorf("incorrectly formatted input: %s", *element.Value)
+	}
+	name := parts[0]
+	spec := parts[1]
+	conf, err := parseLinterSpec(name, spec)
+	if err != nil {
+		return fmt.Errorf("incorrectly formatted input [%s], err: %v", *element.Value, err)
+	}
+	config.Linters[name] = StringOrLinterConfig(conf)
+	return nil
 }
 
 func loadConfig(app *kingpin.Application, element *kingpin.ParseElement, ctx *kingpin.ParseContext) error {
@@ -342,19 +358,7 @@ func lintersFromConfig(config *Config) map[string]*Linter {
 	out := map[string]*Linter{}
 	config.Enable = replaceWithMegacheck(config.Enable, config.EnableAll)
 	for _, name := range config.Enable {
-		var linter *Linter
-		customSpec, customSpecOK := config.Linters[name]
-		override, overrideOK := config.LinterOverrides[name]
-		switch {
-		case overrideOK && customSpecOK:
-			warning("Linter %s has both a custom spec and a custom override defined. Ignoring custom override", name)
-			linter = getLinterByName(name, customSpec)
-		case overrideOK:
-			linter = getLinterByOverride(name, override)
-		default:
-			linter = getLinterByName(name, customSpec)
-		}
-
+		linter := getLinterByName(name, LinterConfig(config.Linters[name]))
 		if config.Fast && !linter.IsFast {
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -352,8 +352,6 @@ func relativePackagePath(dir string) string {
 	return "./" + dir
 }
 
-// NB: emits a warning if a linter config is specified in both config.Linters
-// and config.LinterOverrides.
 func lintersFromConfig(config *Config) map[string]*Linter {
 	out := map[string]*Linter{}
 	config.Enable = replaceWithMegacheck(config.Enable, config.EnableAll)

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func cliLinterOverrides(app *kingpin.Application, element *kingpin.ParseElement,
 	spec := parts[1]
 	conf, err := parseLinterConfigSpec(name, spec)
 	if err != nil {
-		return fmt.Errorf("incorrectly formatted input [%s], err: %v", *element.Value, err)
+		return fmt.Errorf("incorrectly formatted input: %s", *element.Value)
 	}
 	config.Linters[name] = StringOrLinterConfig(conf)
 	return nil

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func cliLinterOverrides(app *kingpin.Application, element *kingpin.ParseElement,
 	}
 	name := parts[0]
 	spec := parts[1]
-	conf, err := parseLinterSpec(name, spec)
+	conf, err := parseLinterConfigSpec(name, spec)
 	if err != nil {
 		return fmt.Errorf("incorrectly formatted input [%s], err: %v", *element.Value, err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -162,3 +162,91 @@ func TestAddPath(t *testing.T) {
 	expected := []string{"existing", "new"}
 	assert.Equal(t, expected, addPath(paths, "new"))
 }
+
+func TestLinterFlags(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	app := kingpin.New("test-app", "")
+	setupFlags(app)
+	_, err := app.Parse([]string{"--linter", "a:b:c"})
+	require.NoError(t, err)
+	linter, ok := config.Linters["a"]
+	assert.True(t, ok)
+	assert.Equal(t, "b", linter.Command)
+	assert.Equal(t, "c", linter.Pattern)
+}
+
+func TestHistoricalLinterConfig(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	tmpfile, err := ioutil.TempFile("", "test-config")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(`{"Linters": {"linter": "command:path"} }`))
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+
+	app := kingpin.New("test-app", "")
+	setupFlags(app)
+
+	_, err = app.Parse([]string{"--config", tmpfile.Name()})
+	require.NoError(t, err)
+	linter, ok := config.Linters["linter"]
+	assert.True(t, ok)
+	assert.Equal(t, "command", linter.Command)
+	assert.Equal(t, "path", linter.Pattern)
+}
+
+func TestMapLinterConfig(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	tmpfile, err := ioutil.TempFile("", "test-config")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(`{"Linters":
+		{"linter":
+			{ "Command": "command" }}}`))
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+
+	app := kingpin.New("test-app", "")
+	setupFlags(app)
+
+	_, err = app.Parse([]string{"--config", tmpfile.Name()})
+	require.NoError(t, err)
+	linter, ok := config.Linters["linter"]
+	assert.True(t, ok)
+	assert.Equal(t, "command", linter.Command)
+	assert.Equal(t, "", linter.Pattern)
+}
+
+func TestMapAndCliLinterConfig(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	tmpfile, err := ioutil.TempFile("", "test-config")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(`{"Linters":
+		{"linter": { "Command": "command" }}}`))
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
+
+	app := kingpin.New("test-app", "")
+	setupFlags(app)
+
+	_, err = app.Parse([]string{
+		"--config", tmpfile.Name(),
+		"--linter", "linter:command:pattern"})
+	require.NoError(t, err)
+	linter, ok := config.Linters["linter"]
+	assert.True(t, ok)
+	assert.Equal(t, "command", linter.Command)
+	assert.Equal(t, "pattern", linter.Pattern)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -163,7 +163,7 @@ func TestAddPath(t *testing.T) {
 	assert.Equal(t, expected, addPath(paths, "new"))
 }
 
-func TestLinterFlags(t *testing.T) {
+func TestSetupFlagsLinterFlag(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()
 
@@ -177,7 +177,7 @@ func TestLinterFlags(t *testing.T) {
 	assert.Equal(t, "c", linter.Pattern)
 }
 
-func TestHistoricalLinterConfig(t *testing.T) {
+func TestSetupFlagsConfigWithLinterString(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()
 
@@ -200,7 +200,7 @@ func TestHistoricalLinterConfig(t *testing.T) {
 	assert.Equal(t, "path", linter.Pattern)
 }
 
-func TestMapLinterConfig(t *testing.T) {
+func TestSetupFlagsConfigWithLinterMap(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()
 
@@ -225,7 +225,7 @@ func TestMapLinterConfig(t *testing.T) {
 	assert.Equal(t, "", linter.Pattern)
 }
 
-func TestMapAndCliLinterConfig(t *testing.T) {
+func TestSetupFlagsConfigAndLinterFlag(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()
 
@@ -234,7 +234,7 @@ func TestMapAndCliLinterConfig(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	_, err = tmpfile.Write([]byte(`{"Linters":
-		{"linter": { "Command": "command" }}}`))
+		{"linter": { "Command": "some-command" }}}`))
 	require.NoError(t, err)
 	require.NoError(t, tmpfile.Close())
 


### PR DESCRIPTION
This PR allows users to specify command/pattern overrides individually, falling back to the defaults for un-specified portions. 

E.g. here's what my config looked prior to this PR:

```
{
  "Linters": {
    "unused": "unused -tags integration:PATH:LINE:COL:MESSAGE",
    "gosimple": "gosimple -tags integration:PATH:LINE:COL:MESSAGE"
  },
  "Enable": [
    "deadcode",
    "varcheck",
    "structcheck",
    "goconst",
    "ineffassign",
    "unconvert",
    "misspell",
    "gosimple",
    "unused"
]}
```

here's what it looks like after: 
```
{
  "Linters": {
    "unused":   { "Command": "unused -tags integration"   },
    "gosimple": { "Command": "gosimple -tags integration" }
  },
  "Enable": [
    "deadcode",
    "varcheck",
    "structcheck",
    "goconst",
    "ineffassign",
    "unconvert",
    "misspell",
    "gosimple",
    "unused"
]}
```