### PR TITLE
Support setting of all linter config fields from the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Linters supports the following fields:
   * `packages` - call the linter once with a list of all the package paths
   * `files-by-package` - call the linter once per package with a list of the
     files in the package.
+  * `single-directory` - call the linter once per directory
 
 The config for default linters can be overridden by using the name of the
 linter.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
     - [2. Analyse the debug output](#2-analyse-the-debug-output)
     - [3. Report an issue.](#3-report-an-issue)
   - [How do I filter issues between two git refs?](#how-do-i-filter-issues-between-two-git-refs)
-- [Details](#details)
 - [Checkstyle XML format](#checkstyle-xml-format)
 
 <!-- /MarkdownTOC -->
@@ -91,8 +90,8 @@ Additional linters can be added through the command line with `--linter=NAME:COM
 ## Configuration file
 
 gometalinter now supports a JSON configuration file which can be loaded via
-`--config=<file>`. The format of this file is determined by the Config struct
-in `config.go`.
+`--config=<file>`. The format of this file is determined by the `Config` struct
+in [config.go](https://github.com/alecthomas/gometalinter/blob/master/config.go).
 
 The configuration file mostly corresponds to command-line flags, with the following exceptions:
 
@@ -106,6 +105,33 @@ Here is an example configuration file:
 {
   "Enable": ["deadcode", "unconvert"]
 }
+```
+
+### Adding Custom linters
+
+Linters can be added and customized from the config file using the `Linters` field.
+Linters supports the following fields:
+
+* `Command` - the path to the linter binary and any default arguments
+* `Pattern` - a regular expression used to parse the linter output
+* `IsFast` - if the linter should be run when the `--fast` flag is used
+* `PartitionStrategy` - how paths args should be passed to the linter command:
+  * `directories` - call the linter once with a list of all the directories
+  * `files` - call the linter once with a list of all the files
+  * `packages` - call the linter once with a list of all the package paths
+  * `files-by-package` - call the linter once per package with a list of the
+    files in the package.
+
+The config for default linters can be overridden by using the name of the
+linter.
+
+Additional linters can be configured via the command line using the format
+`NAME:COMMAND:PATTERN`.
+
+Example:
+
+```
+$ gometalinter --linter='vet:go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf:PATH:LINE:MESSAGE' .
 ```
 
 ## Installing
@@ -306,21 +332,6 @@ gometalinter |& revgrep               # If unstaged changes or untracked files, 
 gometalinter |& revgrep               # Else show issues in the last commit.
 gometalinter |& revgrep master        # Show issues between master and HEAD (or any other reference).
 gometalinter |& revgrep origin/master # Show issues that haven't been pushed.
-```
-
-## Details
-
-Additional linters can be configured via the command line:
-
-```
-$ gometalinter --linter='vet:go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf:PATH:LINE:MESSAGE' .
-stutter.go:21:15:warning: error return value not checked (defer a.Close()) (errcheck)
-stutter.go:22:15:warning: error return value not checked (defer a.Close()) (errcheck)
-stutter.go:27:6:warning: error return value not checked (doit()           // test for errcheck) (errcheck)
-stutter.go:9::warning: unused global variable unusedGlobal (varcheck)
-stutter.go:13::warning: unused struct field MyStruct.Unused (structcheck)
-stutter.go:12:6:warning: exported type MyStruct should have comment or be unexported (golint)
-stutter.go:16:6:warning: exported type PublicUndocumented should have comment or be unexported (deadcode)
 ```
 
 ## Checkstyle XML format

--- a/config.go
+++ b/config.go
@@ -60,7 +60,8 @@ type StringOrLinterConfig LinterConfig
 func (c *StringOrLinterConfig) UnmarshalJSON(raw []byte) error {
 	var linterConfig LinterConfig
 	// first try to un-marshall directly into struct
-	if err := json.Unmarshal(raw, &linterConfig); err == nil {
+	origErr := json.Unmarshal(raw, &linterConfig)
+	if origErr == nil {
 		*c = StringOrLinterConfig(linterConfig)
 		return nil
 	}
@@ -68,7 +69,7 @@ func (c *StringOrLinterConfig) UnmarshalJSON(raw []byte) error {
 	// i.e. bytes didn't represent the struct, treat them as a string
 	var linterSpec string
 	if err := json.Unmarshal(raw, &linterSpec); err != nil {
-		return err
+		return origErr
 	}
 	linter, err := parseLinterConfigSpec("", linterSpec)
 	if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinterConfigUnmarshalJSON(t *testing.T) {
+	source := `{
+		"Command": "/bin/custom",
+		"PartitionStrategy": "directories"
+	}`
+	var config StringOrLinterConfig
+	err := json.Unmarshal([]byte(source), &config)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/custom", config.Command)
+	assert.Equal(t, functionName(partitionPathsAsDirectories), functionName(config.PartitionStrategy))
+}

--- a/linters_test.go
+++ b/linters_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,10 +21,20 @@ func TestNewLinterWithCustomLinter(t *testing.T) {
 
 func TestGetLinterByName(t *testing.T) {
 	config := LinterConfig{
-		Command: "aligncheck",
-		Pattern: "path",
+		Command:           "aligncheck",
+		Pattern:           "path",
+		InstallFrom:       "./install/path",
+		PartitionStrategy: partitionPathsAsDirectories,
+		IsFast:            true,
 	}
 	overrideConfig := getLinterByName(config.Command, config)
-	require.Equal(t, config.Command, overrideConfig.Command)
-	require.Equal(t, config.Pattern, overrideConfig.Pattern)
+	assert.Equal(t, config.Command, overrideConfig.Command)
+	assert.Equal(t, config.Pattern, overrideConfig.Pattern)
+	assert.Equal(t, config.InstallFrom, overrideConfig.InstallFrom)
+	assert.Equal(t, functionName(config.PartitionStrategy), functionName(overrideConfig.PartitionStrategy))
+	assert.Equal(t, config.IsFast, overrideConfig.IsFast)
+}
+
+func functionName(i interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 }

--- a/partition.go
+++ b/partition.go
@@ -26,6 +26,8 @@ func (ps *partitionStrategy) UnmarshalJSON(raw []byte) error {
 		*ps = partitionPathsAsPackages
 	case "files-by-package":
 		*ps = partitionPathsAsFilesGroupedByPackage
+	case "single-directory":
+		*ps = partitionPathsByDirectory
 	default:
 		return fmt.Errorf("unknown parition strategy %s", strategyName)
 	}
@@ -150,4 +152,12 @@ func packageNameFromPath(path string) (string, error) {
 		return rel, nil
 	}
 	return "", fmt.Errorf("%s not in GOPATH", path)
+}
+
+func partitionPathsByDirectory(cmdArgs []string, paths []string) ([][]string, error) {
+	parts := [][]string{}
+	for _, path := range paths {
+		parts = append(parts, append(cmdArgs, path))
+	}
+	return parts, nil
 }

--- a/partition.go
+++ b/partition.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 )
@@ -9,6 +10,27 @@ import (
 const MaxCommandBytes = 32000
 
 type partitionStrategy func([]string, []string) ([][]string, error)
+
+func (ps *partitionStrategy) UnmarshalJSON(raw []byte) error {
+	var strategyName string
+	if err := json.Unmarshal(raw, &strategyName); err != nil {
+		return err
+	}
+
+	switch strategyName {
+	case "directories":
+		*ps = partitionPathsAsDirectories
+	case "files":
+		*ps = partitionPathsAsFiles
+	case "packages":
+		*ps = partitionPathsAsPackages
+	case "files-by-package":
+		*ps = partitionPathsAsFilesGroupedByPackage
+	default:
+		return fmt.Errorf("unknown parition strategy %s", strategyName)
+	}
+	return nil
+}
 
 func pathsToFileGlobs(paths []string) ([]string, error) {
 	filePaths := []string{}
@@ -22,7 +44,7 @@ func pathsToFileGlobs(paths []string) ([]string, error) {
 	return filePaths, nil
 }
 
-func partitionToMaxArgSize(cmdArgs []string, paths []string) ([][]string, error) {
+func partitionPathsAsDirectories(cmdArgs []string, paths []string) ([][]string, error) {
 	return partitionToMaxSize(cmdArgs, paths, MaxCommandBytes), nil
 }
 
@@ -72,15 +94,15 @@ func (p *sizePartitioner) end() [][]string {
 	return p.parts
 }
 
-func partitionToMaxArgSizeWithFileGlobs(cmdArgs []string, paths []string) ([][]string, error) {
+func partitionPathsAsFiles(cmdArgs []string, paths []string) ([][]string, error) {
 	filePaths, err := pathsToFileGlobs(paths)
 	if err != nil || len(filePaths) == 0 {
 		return nil, err
 	}
-	return partitionToMaxArgSize(cmdArgs, filePaths)
+	return partitionPathsAsDirectories(cmdArgs, filePaths)
 }
 
-func partitionToPackageFileGlobs(cmdArgs []string, paths []string) ([][]string, error) {
+func partitionPathsAsFilesGroupedByPackage(cmdArgs []string, paths []string) ([][]string, error) {
 	parts := [][]string{}
 	for _, path := range paths {
 		filePaths, err := pathsToFileGlobs([]string{path})
@@ -95,12 +117,12 @@ func partitionToPackageFileGlobs(cmdArgs []string, paths []string) ([][]string, 
 	return parts, nil
 }
 
-func partitionToMaxArgSizeWithPackagePaths(cmdArgs []string, paths []string) ([][]string, error) {
+func partitionPathsAsPackages(cmdArgs []string, paths []string) ([][]string, error) {
 	packagePaths, err := pathsToPackagePaths(paths)
 	if err != nil || len(packagePaths) == 0 {
 		return nil, err
 	}
-	return partitionToMaxArgSize(cmdArgs, packagePaths)
+	return partitionPathsAsDirectories(cmdArgs, packagePaths)
 }
 
 func pathsToPackagePaths(paths []string) ([]string, error) {

--- a/partition_test.go
+++ b/partition_test.go
@@ -38,7 +38,7 @@ func TestPartitionToPackageFileGlobs(t *testing.T) {
 		mkGoFile(t, dir, "other.go")
 	}
 
-	parts, err := partitionToPackageFileGlobs(cmdArgs, paths)
+	parts, err := partitionPathsAsFilesGroupedByPackage(cmdArgs, paths)
 	require.NoError(t, err)
 	expected := [][]string{
 		append(cmdArgs, packagePaths(paths[0], "file.go", "other.go")...),
@@ -62,7 +62,7 @@ func TestPartitionToPackageFileGlobsNoFiles(t *testing.T) {
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
-	parts, err := partitionToPackageFileGlobs(cmdArgs, paths)
+	parts, err := partitionPathsAsFilesGroupedByPackage(cmdArgs, paths)
 	require.NoError(t, err)
 	assert.Len(t, parts, 0)
 }
@@ -74,7 +74,7 @@ func TestPartitionToMaxArgSizeWithFileGlobsNoFiles(t *testing.T) {
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
-	parts, err := partitionToMaxArgSizeWithFileGlobs(cmdArgs, paths)
+	parts, err := partitionPathsAsFiles(cmdArgs, paths)
 	require.NoError(t, err)
 	assert.Len(t, parts, 0)
 }

--- a/partition_test.go
+++ b/partition_test.go
@@ -97,3 +97,18 @@ func fakeGoPath(t *testing.T, path string) func() {
 	require.NoError(t, os.Setenv("GOPATH", path))
 	return func() { require.NoError(t, os.Setenv("GOPATH", oldpath)) }
 }
+
+func TestPartitionPathsByDirectory(t *testing.T) {
+	cmdArgs := []string{"/usr/bin/foo", "-c"}
+	paths := []string{"one", "two", "three"}
+
+	parts, err := partitionPathsByDirectory(cmdArgs, paths)
+	require.NoError(t, err)
+	expected := [][]string{
+		append(cmdArgs, "one"),
+		append(cmdArgs, "two"),
+		append(cmdArgs, "three"),
+	}
+	assert.Equal(t, expected, parts)
+
+}


### PR DESCRIPTION
Adds support for setting `IsFast` and `PartitionStrategy` from the config file. Technically `InstallFrom` can be set, but it doesn't do anything just yet because `--install` always reads the defaultLinters instead of any config.

Updates the README to document linter settings in the configuration file.

Also adds a `single-directory` partition strategy that might allow for a workaround for #351