### PR TITLE
Fix gotype with multi-package directory (restores pre-partition-strategy behaviour)

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -280,7 +280,7 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `gotype -e {tests=-t}`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "golang.org/x/tools/cmd/gotype",
-		PartitionStrategy: partitionPathsAsFilesGroupedByPackage,
+		PartitionStrategy: partitionPathsByDirectory,
 		defaultEnabled:    true,
 		IsFast:            true,
 	},


### PR DESCRIPTION
Fixes #355

Using `gotype` will work as it did before, it will only lint the non-external packages. To also lint external packages you should be able to add a second version of `gotype` to the config:

```json
{
  "Linters": {
    "gotypeexternal": {
        "Command": "gotype -x",
        "Pattern": "PATH:LINE:COL:MESSAGE",
        "PartitionStrategy": "partitionPathsByDirectory"
    }
  },
  "Enable": ["gotypeexternal", ...]
}
```