### PR TITLE
Warn on ununsed directive

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,6 +52,9 @@ type Config struct { // nolint: aligncheck
 	Aggregate       bool
 	EnableAll       bool
 
+	// Warn if a nolint directive was never matched to a linter issue
+	WarnUnmatchedDirective bool
+
 	formatTemplate *template.Template
 }
 

--- a/directives.go
+++ b/directives.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -14,6 +15,7 @@ type ignoredRange struct {
 	col        int
 	start, end int
 	linters    []string
+	matched    bool
 }
 
 func (i *ignoredRange) matches(issue *Issue) bool {
@@ -33,6 +35,14 @@ func (i *ignoredRange) matches(issue *Issue) bool {
 
 func (i *ignoredRange) near(col, start int) bool {
 	return col == i.col && i.end == start-1
+}
+
+func (i *ignoredRange) String() string {
+	linters := strings.Join(i.linters, ",")
+	if len(i.linters) == 0 {
+		linters = "all"
+	}
+	return fmt.Sprintf("%s:%d-%d", linters, i.start, i.end)
 }
 
 type ignoredRanges []*ignoredRange
@@ -66,10 +76,41 @@ func (d *directiveParser) IsIgnored(issue *Issue) bool {
 	d.lock.Unlock()
 	for _, r := range ranges {
 		if r.matches(issue) {
+			debug("nolint: matched %s to issue %s", r, issue)
+			r.matched = true
 			return true
 		}
 	}
 	return false
+}
+
+// Unmatched returns all the ranges which were never used to ignore an issue
+func (d *directiveParser) Unmatched() map[string]ignoredRanges {
+	unmatched := map[string]ignoredRanges{}
+	for path, ranges := range d.files {
+		for _, ignore := range ranges {
+			if !ignore.matched {
+				unmatched[path] = append(unmatched[path], ignore)
+			}
+		}
+	}
+	return unmatched
+}
+
+// LoadFiles from a list of directories
+func (d *directiveParser) LoadFiles(paths []string) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	filenames, err := pathsToFileGlobs(paths)
+	if err != nil {
+		return err
+	}
+	for _, filename := range filenames {
+		ranges := d.parseFile(filename)
+		sort.Sort(ranges)
+		d.files[filename] = ranges
+	}
+	return nil
 }
 
 // Takes a set of ignoredRanges, determines if they immediately precede a statement
@@ -150,7 +191,28 @@ func filterIssuesViaDirectives(directives *directiveParser, issues chan *Issue) 
 				out <- issue
 			}
 		}
+
+		if config.WarnUnmatchedDirective {
+			for _, issue := range warnOnUnusedDirective(directives) {
+				out <- issue
+			}
+		}
 		close(out)
 	}()
+	return out
+}
+
+func warnOnUnusedDirective(directives *directiveParser) []*Issue {
+	out := []*Issue{}
+	for path, ranges := range directives.Unmatched() {
+		for _, ignore := range ranges {
+			issue, _ := NewIssue("nolint", config.formatTemplate)
+			issue.Path = path
+			issue.Line = ignore.start
+			issue.Col = ignore.col
+			issue.Message = "nolint directive did not match any issue"
+			out = append(out, issue)
+		}
+	}
 	return out
 }

--- a/directives_test.go
+++ b/directives_test.go
@@ -1,1 +1,42 @@
 package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgnoreRangeMatch(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		issue    Issue
+		linters  []string
+		expected bool
+	}{
+		{
+			doc:   "unmatched line",
+			issue: Issue{Line: 100},
+		},
+		{
+			doc:      "matched line, all linters",
+			issue:    Issue{Line: 5},
+			expected: true,
+		},
+		{
+			doc:     "matched line, unmatched linter",
+			issue:   Issue{Line: 5},
+			linters: []string{"vet"},
+		},
+		{
+			doc:      "matched line and linters",
+			issue:    Issue{Line: 20, Linter: "vet"},
+			linters:  []string{"vet"},
+			expected: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		ir := ignoredRange{col: 20, start: 5, end: 20, linters: testcase.linters}
+		assert.Equal(t, testcase.expected, ir.matches(&testcase.issue), testcase.doc)
+	}
+}

--- a/issue.go
+++ b/issue.go
@@ -16,7 +16,7 @@ const DefaultIssueFormat = "{{.Path}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Se
 type Severity string
 
 // Linter message severity levels.
-const ( // nolint: deadcode
+const (
 	Error   Severity = "error"
 	Warning Severity = "warning"
 )
@@ -36,6 +36,7 @@ type Issue struct {
 func NewIssue(linter string, formatTmpl *template.Template) (*Issue, error) {
 	issue := &Issue{
 		Line:       1,
+		Severity:   Warning,
 		Linter:     linter,
 		formatTmpl: formatTmpl,
 	}

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func setupFlags(app *kingpin.Application) {
 	app.Flag("checkstyle", "Generate checkstyle XML rather than standard line-based output.").BoolVar(&config.Checkstyle)
 	app.Flag("enable-gc", "Enable GC for linters (useful on large repositories).").BoolVar(&config.EnableGC)
 	app.Flag("aggregate", "Aggregate issues reported by several linters.").BoolVar(&config.Aggregate)
+	app.Flag("warn-unmatched-nolint", "Warn if a nolint directive is not matched with an issue.").BoolVar(&config.WarnUnmatchedDirective)
 	app.GetFlag("help").Short('h')
 }
 


### PR DESCRIPTION
Fixes #354

Adds a new flag to enable the new behaviour. When the flag is enabled all the files are parsed for directives (otherwise warnings would only exist for files with at least one issue).  Once all linting is done all the ignore ranges are checked and new issues are created for any ignore range that was never matched to an issue.

The order of issue processing operations was changed to filter before sorting so that the new `nolint` issues are properly sorted. 