### PR TITLE
Improve error message in the case of an unknown linter

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -184,21 +184,17 @@ func defaultEnabled() []string {
 
 func validateLinters(linters map[string]*Linter, config *Config) error {
 	var unknownLinters []string
-	for name, _ := range linters {
+	for name := range linters {
 		if _, isDefault := defaultLinters[name]; !isDefault {
 			if _, isCustom := config.Linters[name]; !isCustom {
 				unknownLinters = append(unknownLinters, name)
 			}
 		}
 	}
-	switch len(unknownLinters) {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("unknown linter: %s", unknownLinters[0])
-	default:
+	if len(unknownLinters) > 0 {
 		return fmt.Errorf("unknown linters: %s", strings.Join(unknownLinters, ", "))
 	}
+	return nil
 }
 
 const vetPattern = `^(?:vet:.*?\.go:\s+(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*))|(?:(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*))$`

--- a/linters.go
+++ b/linters.go
@@ -182,6 +182,25 @@ func defaultEnabled() []string {
 	return enabled
 }
 
+func validateLinters(linters map[string]*Linter, config *Config) error {
+	var unknownLinters []string
+	for name, _ := range linters {
+		if _, isDefault := defaultLinters[name]; !isDefault {
+			if _, isCustom := config.Linters[name]; !isCustom {
+				unknownLinters = append(unknownLinters, name)
+			}
+		}
+	}
+	switch len(unknownLinters) {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("unknown linter: %s", unknownLinters[0])
+	default:
+		return fmt.Errorf("unknown linters: %s", strings.Join(unknownLinters, ", "))
+	}
+}
+
 const vetPattern = `^(?:vet:.*?\.go:\s+(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*))|(?:(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*))$`
 
 var defaultLinters = map[string]LinterConfig{

--- a/linters_test.go
+++ b/linters_test.go
@@ -35,6 +35,24 @@ func TestGetLinterByName(t *testing.T) {
 	assert.Equal(t, config.IsFast, overrideConfig.IsFast)
 }
 
+func TestValidateLinters(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	config = &Config{
+		Enable: []string{"_dummylinter_"},
+	}
+
+	err := validateLinters(lintersFromConfig(config), config)
+	require.Error(t, err, "expected unknown linter error for _dummylinter_")
+
+	config = &Config{
+		Enable: defaultEnabled(),
+	}
+	err = validateLinters(lintersFromConfig(config), config)
+	require.NoError(t, err)
+}
+
 func functionName(i interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 }

--- a/main.go
+++ b/main.go
@@ -201,10 +201,8 @@ Severity override map (default is "warning"):
 	paths := resolvePaths(*pathsArg, config.Skip)
 
 	linters := lintersFromConfig(config)
-	if err := validateLinters(linters, config); err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
-	}
+	err := validateLinters(linters, config)
+	kingpin.FatalIfError(err, "")
 
 	issues, errch := runLinters(linters, paths, config.Concurrency, exclude, include)
 	status := 0

--- a/main.go
+++ b/main.go
@@ -170,25 +170,6 @@ func formatSeverity() string {
 	return w.String()
 }
 
-func validateLinters(linters map[string]*Linter, config *Config) error {
-	var unknownLinters []string
-	for name, _ := range linters {
-		if _, isDefault := defaultLinters[name]; !isDefault {
-			if _, isCustom := config.Linters[name]; !isCustom {
-				unknownLinters = append(unknownLinters, name)
-			}
-		}
-	}
-	switch len(unknownLinters) {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("unknown linter: %s", unknownLinters[0])
-	default:
-		return fmt.Errorf("unknown linters: %s", strings.Join(unknownLinters, ", "))
-	}
-}
-
 func main() {
 	pathsArg := kingpin.Arg("path", "Directories to lint. Defaults to \".\". <path>/... will recurse.").Strings()
 	app := kingpin.CommandLine

--- a/main_test.go
+++ b/main_test.go
@@ -225,19 +225,6 @@ func TestSetupFlagsConfigWithLinterMap(t *testing.T) {
 	assert.Equal(t, "", linter.Pattern)
 }
 
-func TestUnknownLinter(t *testing.T) {
-	originalConfig := *config
-	defer func() { config = &originalConfig }()
-
-	app := kingpin.New("test-app", "")
-	setupFlags(app)
-	_, err := app.Parse([]string{"--enable=_dummylinter_"})
-	require.NoError(t, err)
-
-	err = validateLinters(lintersFromConfig(config), config)
-	require.Error(t, err, "expected unknown linter error for _dummylinter_")
-}
-
 func TestSetupFlagsConfigAndLinterFlag(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()

--- a/main_test.go
+++ b/main_test.go
@@ -225,6 +225,19 @@ func TestSetupFlagsConfigWithLinterMap(t *testing.T) {
 	assert.Equal(t, "", linter.Pattern)
 }
 
+func TestUnknownLinter(t *testing.T) {
+	originalConfig := *config
+	defer func() { config = &originalConfig }()
+
+	app := kingpin.New("test-app", "")
+	setupFlags(app)
+	_, err := app.Parse([]string{"--enable=_dummylinter_"})
+	require.NoError(t, err)
+
+	err = validateLinters(lintersFromConfig(config), config)
+	require.Error(t, err, "expected unknown linter error for _dummylinter_")
+}
+
 func TestSetupFlagsConfigAndLinterFlag(t *testing.T) {
 	originalConfig := *config
 	defer func() { config = &originalConfig }()


### PR DESCRIPTION
Discovered in #369

When an unknown linter is enabled, raise an error identifying which linter(s) are unknown, rather than failing with:

    WARNING: invalid command ""

Note: linters defined with the --linter flag are not considered unknown and will not fail with this error.