### PR TITLE
update vendored linter honnef.co/go/tools to tag 2017.2

### DIFF
--- a/_linters/src/honnef.co/go/tools/lint/lint.go
+++ b/_linters/src/honnef.co/go/tools/lint/lint.go
@@ -693,9 +693,11 @@ func Preamble(f *ast.File) string {
 }
 
 func IsPointerLike(T types.Type) bool {
-	switch T.Underlying().(type) {
+	switch T := T.Underlying().(type) {
 	case *types.Interface, *types.Chan, *types.Map, *types.Pointer:
 		return true
+	case *types.Basic:
+		return T.Kind() == types.UnsafePointer
 	}
 	return false
 }

--- a/_linters/src/honnef.co/go/tools/version/version.go
+++ b/_linters/src/honnef.co/go/tools/version/version.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-const Version = "devel"
+const Version = "2017.2"
 
 func Print() {
 	if Version == "devel" {

--- a/_linters/src/manifest
+++ b/_linters/src/manifest
@@ -321,8 +321,8 @@
 			"importpath": "honnef.co/go/tools",
 			"repository": "https://github.com/dominikh/go-tools",
 			"vcs": "git",
-			"revision": "15d446f3efa09ffb7dc2745ae3086c3304250e78",
-			"branch": "master",
+			"revision": "50914165a1ae448f1608c6c325d052313396182e",
+			"branch": "HEAD",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
Closes https://github.com/alecthomas/gometalinter/issues/389

Commands:
```
gvt delete honnef.co/go/tools
gvt fetch -tag 2017.2 honnef.co/go/tools
```