### PR TITLE
Fix gas partition stategy

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -235,7 +235,7 @@ var defaultLinters = map[string]LinterConfig{
 		Command:           `gas -fmt=csv`,
 		Pattern:           `^(?P<path>.*?\.go),(?P<line>\d+),(?P<message>[^,]+,[^,]+,[^,]+)`,
 		InstallFrom:       "github.com/GoASTScanner/gas",
-		PartitionStrategy: partitionPathsAsDirectories,
+		PartitionStrategy: partitionPathsAsFiles,
 		defaultEnabled:    true,
 		IsFast:            true,
 	},

--- a/regressiontests/gas_test.go
+++ b/regressiontests/gas_test.go
@@ -1,0 +1,37 @@
+package regressiontests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGas(t *testing.T) {
+	t.Parallel()
+	dir := fs.NewDir(t, "test-gas",
+		fs.WithFile("file.go", gasFileErrorUnhandled("root")),
+		fs.WithDir("sub",
+			fs.WithFile("file.go", gasFileErrorUnhandled("sub"))))
+	defer dir.Remove()
+	expected := Issues{
+		{Linter: "gas", Severity: "warning", Path: "file.go", Line: 3, Col: 0, Message: "Errors unhandled.,LOW,HIGH"},
+		{Linter: "gas", Severity: "warning", Path: "sub/file.go", Line: 3, Col: 0, Message: "Errors unhandled.,LOW,HIGH"},
+	}
+	actual := RunLinter(t, "gas", dir.Path())
+	assert.Equal(t, expected, actual)
+}
+
+func gasFileErrorUnhandled(pkg string) string {
+	return fmt.Sprintf(`package %s
+	func badFunction() string {
+		u, _ := ErrorHandle()
+		return u
+	}
+	
+	func ErrorHandle() (u string, err error) {
+		return u
+	}
+	`, pkg)
+}


### PR DESCRIPTION
Executing gas with argument only with the path to directory always returns that no files are analyzed:
```
$ gas some-folder
Summary:
   Files: 0
   Lines: 0
   Nosec: 0
  Issues: 0
```
In order gas to analyze the files, every file should be given as an argument.


