### PR TITLE
misspell: Add locale setting to misspell

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type Config struct { // nolint: maligned
 	Vendor          bool
 	Cyclo           int
 	LineLength      int
+	MisspellLocale  string
 	MinConfidence   float64
 	MinOccurrences  int
 	MinConstLength  int
@@ -128,6 +129,7 @@ var config = &Config{
 	Concurrency:     runtime.NumCPU(),
 	Cyclo:           10,
 	LineLength:      80,
+	MisspellLocale:  "",
 	MinConfidence:   0.8,
 	MinOccurrences:  3,
 	MinConstLength:  3,

--- a/execute.go
+++ b/execute.go
@@ -82,6 +82,7 @@ func runLinters(linters map[string]*Linter, paths []string, concurrency int, exc
 		"duplthreshold":    fmt.Sprintf("%d", config.DuplThreshold),
 		"mincyclo":         fmt.Sprintf("%d", config.Cyclo),
 		"maxlinelength":    fmt.Sprintf("%d", config.LineLength),
+		"misspelllocale":   fmt.Sprintf("%s", config.MisspellLocale),
 		"min_confidence":   fmt.Sprintf("%f", config.MinConfidence),
 		"min_occurrences":  fmt.Sprintf("%d", config.MinOccurrences),
 		"min_const_length": fmt.Sprintf("%d", config.MinConstLength),

--- a/linters.go
+++ b/linters.go
@@ -328,7 +328,7 @@ var defaultLinters = map[string]LinterConfig{
 		defaultEnabled:    true,
 	},
 	"misspell": {
-		Command:           `misspell -j 1`,
+		Command:           `misspell -j 1 --locale "{misspelllocale}"`,
 		Pattern:           `PATH:LINE:COL:MESSAGE`,
 		InstallFrom:       "github.com/client9/misspell/cmd/misspell",
 		PartitionStrategy: partitionPathsAsFiles,

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func setupFlags(app *kingpin.Application) {
 	app.Flag("vendor", "Enable vendoring support (skips 'vendor' directories and sets GO15VENDOREXPERIMENT=1).").BoolVar(&config.Vendor)
 	app.Flag("cyclo-over", "Report functions with cyclomatic complexity over N (using gocyclo).").PlaceHolder("10").IntVar(&config.Cyclo)
 	app.Flag("line-length", "Report lines longer than N (using lll).").PlaceHolder("80").IntVar(&config.LineLength)
+	app.Flag("misspell-locale", "Specify locale to use (using misspell).").PlaceHolder("").StringVar(&config.MisspellLocale)
 	app.Flag("min-confidence", "Minimum confidence interval to pass to golint.").PlaceHolder(".80").FloatVar(&config.MinConfidence)
 	app.Flag("min-occurrences", "Minimum occurrences to pass to goconst.").PlaceHolder("3").IntVar(&config.MinOccurrences)
 	app.Flag("min-const-length", "Minimum constant length.").PlaceHolder("3").IntVar(&config.MinConstLength)


### PR DESCRIPTION
This adds a --misspell-locale option to gometalinter. It passes the
desired locale setting to misspell so that you can check for common
typos like "color" which are obviously supposed to read "colour". ;)
Unfortunately there is no Canadian linter at this time, so UK will have
to do for now.

Example:

gometalinter --disable-all --enable=misspell --misspell-locale=UK