### PR TITLE
Take an environment variable as a config filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 )
 
 func setupFlags(app *kingpin.Application) {
-	app.Flag("config", "Load JSON configuration from file.").Action(loadConfig).String()
+	app.Flag("config", "Load JSON configuration from file.").Envar("GOMETALINTER_CONFIG").Action(loadConfig).String()
 	app.Flag("disable", "Disable previously enabled linters.").PlaceHolder("LINTER").Short('D').Action(disableAction).Strings()
 	app.Flag("enable", "Enable previously disabled linters.").PlaceHolder("LINTER").Short('E').Action(enableAction).Strings()
 	app.Flag("linter", "Define a linter.").PlaceHolder("NAME:COMMAND:PATTERN").Action(cliLinterOverrides).StringMap()


### PR DESCRIPTION
I want to use gometalinter as much as possible simple.
I've created an alias, `alias gometalinter=gometalinter --config=~/.config/gometalinter/config.json`.

But It was not so good.

case 1) Switching configurations, I have to type like `\gometalinter --config=...` or `command gometalinter --config=...` (in case of zsh).
case 2) In CIs using docker, gometalinter have to be called as `gometalinter --config=...` for each time.
:

So I think that `gometalinter` should be able to look an envar as a config filename.

## NOTE: 
[kingpin](https://github.com/alecthomas/kingpin) does not kick `Action` on a flag when it is specified by an envar.
(ref: https://github.com/alecthomas/kingpin/issues/175)

So an envar has to be taken by `os.Getenv()` before `kingpin.Parse`.