### PR TITLE
add 'predeclared' as a non-default linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Disabled by default (enable with `--enable=<linter>`):
 - [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - Find unused variables.
 - [safesql](https://github.com/stripe/safesql) - Finds potential SQL injection vulnerabilities.
 - [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) - Statically detect bugs, both obvious and subtle ones.
-- [predeclared](github.com/nishanths/predeclared) - Detect shadowing of predeclared identifiers
+- [predeclared](github.com/nishanths/predeclared) - Find code that shadows predeclared identifiers.
 
 Additional linters can be added through the command line with `--linter=NAME:COMMAND:PATTERN` (see [below](#details)).
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Disabled by default (enable with `--enable=<linter>`):
 - [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - Find unused variables.
 - [safesql](https://github.com/stripe/safesql) - Finds potential SQL injection vulnerabilities.
 - [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) - Statically detect bugs, both obvious and subtle ones.
+- [predeclared](github.com/nishanths/predeclared) - Detect shadowing of predeclared identifiers
 
 Additional linters can be added through the command line with `--linter=NAME:COMMAND:PATTERN` (see [below](#details)).
 
@@ -245,6 +246,7 @@ Installing:
   lll
   gas
   safesql
+  predeclared
 ```
 
 Run it:

--- a/_linters/src/github.com/nishanths/predeclared/LICENSE
+++ b/_linters/src/github.com/nishanths/predeclared/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Nishanth Shanmugham
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_linters/src/github.com/nishanths/predeclared/go18.go
+++ b/_linters/src/github.com/nishanths/predeclared/go18.go
@@ -1,0 +1,9 @@
+// +build go1.8
+
+package main
+
+import "go/doc"
+
+func isPredeclaredIdent(name string) bool {
+	return doc.IsPredeclared(name)
+}

--- a/_linters/src/github.com/nishanths/predeclared/pre_go18.go
+++ b/_linters/src/github.com/nishanths/predeclared/pre_go18.go
@@ -1,0 +1,53 @@
+// +build !go1.8
+
+package main
+
+func isPredeclaredIdent(name string) bool {
+	return predeclaredIdents[name]
+}
+
+// Keep in sync with https://golang.org/ref/spec#Predeclared_identifiers
+var predeclaredIdents = map[string]bool{
+	"bool":       true,
+	"byte":       true,
+	"complex64":  true,
+	"complex128": true,
+	"error":      true,
+	"float32":    true,
+	"float64":    true,
+	"int":        true,
+	"int8":       true,
+	"int16":      true,
+	"int32":      true,
+	"int64":      true,
+	"rune":       true,
+	"string":     true,
+	"uint":       true,
+	"uint8":      true,
+	"uint16":     true,
+	"uint32":     true,
+	"uint64":     true,
+	"uintptr":    true,
+
+	"true":  true,
+	"false": true,
+	"iota":  true,
+
+	"nil": true,
+
+	"append":  true,
+	"cap":     true,
+	"close":   true,
+	"complex": true,
+	"copy":    true,
+	"delete":  true,
+	"imag":    true,
+	"len":     true,
+	"make":    true,
+	"new":     true,
+	"panic":   true,
+	"print":   true,
+	"println": true,
+	"real":    true,
+	"recover": true,
+}

--- a/_linters/src/github.com/nishanths/predeclared/predeclared.go
+++ b/_linters/src/github.com/nishanths/predeclared/predeclared.go
@@ -39,7 +39,6 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
-	"go/doc"
 	"go/parser"
 	"go/scanner"
 	"go/token"
@@ -82,7 +81,7 @@ func initIgnoredIdents() {
 		if ident == "" {
 			continue
 		}
-		if !doc.IsPredeclared(ident) {
+		if !isPredeclaredIdent(ident) {
 			log.Printf("ident %q in -ignore is not a predeclared ident", ident)
 			os.Exit(2)
 		}
@@ -196,14 +195,14 @@ type Issue struct {
 
 func (i Issue) String() string {
 	pos := i.fset.Position(i.ident.Pos())
-	return fmt.Sprintf("%s: %s %s has same name as predeclared identifier", pos, i.kind, i.ident.Name)
+	return fmt.Sprintf("%s: %s %q has same name as predeclared identifier", pos, i.kind, i.ident.Name)
 }
 
 func processFile(fset *token.FileSet, file *ast.File) []Issue {
 	var issues []Issue
 
 	maybeAdd := func(x *ast.Ident, kind string) {
-		if !isIgnoredIdent(x.Name) && doc.IsPredeclared(x.Name) {
+		if !isIgnoredIdent(x.Name) && isPredeclaredIdent(x.Name) {
 			issues = append(issues, Issue{x, kind, fset})
 		}
 	}

--- a/_linters/src/github.com/nishanths/predeclared/predeclared.go
+++ b/_linters/src/github.com/nishanths/predeclared/predeclared.go
@@ -1,0 +1,323 @@
+// Command predeclared prints the names and locations of declarations and
+// fields in the given files that have the same name as one of Go's
+// predeclared identifiers.
+//
+// Exit code
+//
+// The command exits with exit code 1 if an error occurred parsing the given
+// files or if it finds predeclared identifiers being overridden. It exits
+// with exit code 2 if the command was invoked incorrectly.
+//
+// Usage
+//
+// Common usage is:
+//
+//  predeclared file1.go file2.go dir1 dir2
+//
+// which prints the list of issues to standard output.
+// See 'predeclared -h' for help.
+//
+// If the '-q' flag isn't specified, the command never reports struct fields,
+// interface methods, and method names as issues.
+// (These aren't included by default since fields and method are always
+// accessed by a qualifier—à la obj.Field—and hence are less likely to cause
+// confusion when reading code even if they have the same name as a predeclared
+// identifier.)
+//
+// The '-ignore' flag can be used to specify predeclared identifiers to not
+// report issues for. For example, to not report overriding of the predeclared
+// identifiers 'new' and 'real', set the flag like so:
+//
+//  -ignore=new,real
+//
+// The arguments to the command can either be files or directories. If a directory
+// is provided, all Go files in the directory and its subdirectories are checked.
+// If no arguments are specified, the command reads from standard input.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/scanner"
+	"go/token"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const help = `Find declarations and fields that override predeclared identifiers.
+
+Usage:
+  predeclared [flags] [path ...]
+
+Flags:
+  -e	   Report all parse errors, not just the first 10 on different lines
+  -ignore  Comma-separated list of predeclared identifiers to not report on
+  -q       Include method names and field names while checking
+`
+
+func usage() {
+	fmt.Fprintf(os.Stderr, help)
+	os.Exit(2)
+}
+
+var (
+	allErrors = flag.Bool("e", false, "")
+	ignore    = flag.String("ignore", "", "")
+	qualified = flag.Bool("q", false, "")
+)
+
+var exitCode = 0
+var ignoredIdents map[string]bool
+
+func initIgnoredIdents() {
+	for _, s := range strings.Split(*ignore, ",") {
+		ident := strings.TrimSpace(s)
+		if ident == "" {
+			continue
+		}
+		if !doc.IsPredeclared(ident) {
+			log.Printf("ident %q in -ignore is not a predeclared ident", ident)
+			os.Exit(2)
+		}
+		if ignoredIdents == nil {
+			ignoredIdents = make(map[string]bool)
+		}
+		ignoredIdents[ident] = true
+	}
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("predeclared: ")
+
+	flag.Usage = usage
+	flag.Parse()
+	initIgnoredIdents()
+
+	var fset = token.NewFileSet()
+	if flag.NArg() == 0 {
+		handleFile(fset, true, "<standard input>", os.Stdout) // use the same filename that gofmt uses
+	} else {
+		for i := 0; i < flag.NArg(); i++ {
+			path := flag.Arg(i)
+			info, err := os.Stat(path)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				exitCode = 1
+			} else if info.IsDir() {
+				handleDir(fset, path)
+			} else {
+				handleFile(fset, false, path, os.Stdout)
+			}
+		}
+	}
+
+	os.Exit(exitCode)
+}
+
+func parserMode() parser.Mode {
+	if *allErrors {
+		return parser.ParseComments | parser.AllErrors
+	}
+	return parser.ParseComments
+}
+
+func handleFile(fset *token.FileSet, stdin bool, filename string, out io.Writer) {
+	var src []byte
+	var err error
+	if stdin {
+		src, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		src, err = ioutil.ReadFile(filename)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+		return
+	}
+
+	file, err := parser.ParseFile(fset, filename, src, parserMode())
+	if err != nil {
+		scanner.PrintError(os.Stderr, err)
+		exitCode = 1
+		return
+	}
+
+	issues := processFile(fset, file)
+	if len(issues) == 0 {
+		return
+	}
+
+	exitCode = 1
+
+	for _, issue := range issues {
+		fmt.Fprintf(out, "%s\n", issue)
+	}
+}
+
+func handleDir(fset *token.FileSet, p string) {
+	if err := filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !isGoFile(info) {
+			return nil
+		}
+		handleFile(fset, false, path, os.Stdout)
+		return nil
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+	}
+}
+
+func isGoFile(f os.FileInfo) bool {
+	// ignore non-Go files
+	name := f.Name()
+	return !f.IsDir() && !strings.HasPrefix(name, ".") && !strings.HasPrefix(name, "_") && strings.HasSuffix(name, ".go")
+}
+
+func isIgnoredIdent(name string) bool {
+	return ignoredIdents[name]
+}
+
+type Issue struct {
+	ident *ast.Ident
+	kind  string
+	fset  *token.FileSet
+}
+
+func (i Issue) String() string {
+	pos := i.fset.Position(i.ident.Pos())
+	return fmt.Sprintf("%s: %s %s has same name as predeclared identifier", pos, i.kind, i.ident.Name)
+}
+
+func processFile(fset *token.FileSet, file *ast.File) []Issue {
+	var issues []Issue
+
+	maybeAdd := func(x *ast.Ident, kind string) {
+		if !isIgnoredIdent(x.Name) && doc.IsPredeclared(x.Name) {
+			issues = append(issues, Issue{x, kind, fset})
+		}
+	}
+
+	seenValueSpecs := make(map[*ast.ValueSpec]bool)
+
+	// TODO: consider deduping package name issues for files in the
+	// same directory.
+	maybeAdd(file.Name, "package name")
+
+	for _, spec := range file.Imports {
+		if spec.Name == nil {
+			continue
+		}
+		maybeAdd(spec.Name, "import name")
+	}
+
+	// Handle declarations and fields.
+	// https://golang.org/ref/spec#Declarations_and_scope
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.GenDecl:
+			var kind string
+			switch x.Tok {
+			case token.CONST:
+				kind = "const"
+			case token.VAR:
+				kind = "variable"
+			default:
+				return true
+			}
+			for _, spec := range x.Specs {
+				if vspec, ok := spec.(*ast.ValueSpec); ok && !seenValueSpecs[vspec] {
+					seenValueSpecs[vspec] = true
+					for _, name := range vspec.Names {
+						maybeAdd(name, kind)
+					}
+				}
+			}
+			return true
+		case *ast.TypeSpec:
+			maybeAdd(x.Name, "type")
+			return true
+		case *ast.StructType:
+			if *qualified && x.Fields != nil {
+				for _, field := range x.Fields.List {
+					for _, name := range field.Names {
+						maybeAdd(name, "field")
+					}
+				}
+			}
+			return true
+		case *ast.InterfaceType:
+			if *qualified && x.Methods != nil {
+				for _, meth := range x.Methods.List {
+					for _, name := range meth.Names {
+						maybeAdd(name, "method")
+					}
+				}
+			}
+			return true
+		case *ast.FuncDecl:
+			if x.Recv == nil {
+				// it's a function
+				maybeAdd(x.Name, "function")
+			} else {
+				// it's a method
+				if *qualified {
+					maybeAdd(x.Name, "method")
+				}
+			}
+			// add receivers idents
+			if x.Recv != nil {
+				for _, field := range x.Recv.List {
+					for _, name := range field.Names {
+						maybeAdd(name, "receiver")
+					}
+				}
+			}
+			// Params and Results will be checked in the *ast.FuncType case.
+			return true
+		case *ast.FuncType:
+			// add params idents
+			for _, field := range x.Params.List {
+				for _, name := range field.Names {
+					maybeAdd(name, "param")
+				}
+			}
+			// add returns idents
+			if x.Results != nil {
+				for _, field := range x.Results.List {
+					for _, name := range field.Names {
+						maybeAdd(name, "named return")
+					}
+				}
+			}
+			return true
+		case *ast.LabeledStmt:
+			maybeAdd(x.Label, "label")
+			return true
+		case *ast.AssignStmt:
+			// We only care about short variable declarations, which use token.DEFINE.
+			if x.Tok == token.DEFINE {
+				for _, expr := range x.Lhs {
+					if ident, ok := expr.(*ast.Ident); ok {
+						maybeAdd(ident, "variable")
+					}
+				}
+			}
+			return true
+		default:
+			return true
+		}
+	})
+
+	return issues
+}

--- a/_linters/src/manifest
+++ b/_linters/src/manifest
@@ -106,6 +106,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/nishanths/predeclared",
+			"repository": "https://github.com/nishanths/predeclared",
+			"vcs": "git",
+			"revision": "05b9c08a3dcea629402c1af6d77f4ef4dfbebb2e",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/opennota/check",
 			"repository": "https://github.com/opennota/check",
 			"vcs": "git",

--- a/_linters/src/manifest
+++ b/_linters/src/manifest
@@ -109,7 +109,7 @@
 			"importpath": "github.com/nishanths/predeclared",
 			"repository": "https://github.com/nishanths/predeclared",
 			"vcs": "git",
-			"revision": "05b9c08a3dcea629402c1af6d77f4ef4dfbebb2e",
+			"revision": "2cb813fdca83a519b3fc174af0e5dd9f09e65e96",
 			"branch": "master",
 			"notests": true
 		},

--- a/linters.go
+++ b/linters.go
@@ -340,6 +340,13 @@ var defaultLinters = map[string]LinterConfig{
 		InstallFrom:       "github.com/alexkohler/nakedret",
 		PartitionStrategy: partitionPathsAsDirectories,
 	},
+	"predeclared": {
+		Command:           `predeclared`,
+		Pattern:           `PATH:LINE:COL:MESSAGE`,
+		InstallFrom:       "github.com/nishanths/predeclared",
+		PartitionStrategy: partitionPathsAsDirectories,
+		IsFast:            true,
+	},
 	"safesql": {
 		Command:           `safesql`,
 		Pattern:           `^- (?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+)$`,

--- a/package.sh
+++ b/package.sh
@@ -35,6 +35,7 @@ LINTERS="
   github.com/stripe/safesql
   github.com/tsenart/deadcode
   github.com/walle/lll/cmd/lll
+  github.com/nishanths/predeclared
   golang.org/x/tools/cmd/goimports
   golang.org/x/tools/cmd/gotype
   honnef.co/go/tools/cmd/gosimple

--- a/regressiontests/predeclared_test.go
+++ b/regressiontests/predeclared_test.go
@@ -4,8 +4,7 @@ import "testing"
 
 func TestPredeclared(t *testing.T) {
 	t.Parallel()
-	source := `
-package test
+	source := `package test
 var iota = 1
 func recover() interface{} {}
 func copy(a, b []int) {}

--- a/regressiontests/predeclared_test.go
+++ b/regressiontests/predeclared_test.go
@@ -1,0 +1,19 @@
+package regressiontests
+
+import "testing"
+
+func TestPredeclared(t *testing.T) {
+	t.Parallel()
+	source := `
+package test
+var iota = 1
+func recover() interface{} {}
+func copy(a, b []int) {}
+`
+	expected := Issues{
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 2, Col: 5, Message: "variable iota has same name as predeclared identifier"},
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 3, Col: 6, Message: "function recover has same name as predeclared identifier"},
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 4, Col: 6, Message: "function copy has same name as predeclared identifier"},
+	}
+	ExpectIssues(t, "predeclared", source, expected)
+}

--- a/regressiontests/predeclared_test.go
+++ b/regressiontests/predeclared_test.go
@@ -10,9 +10,9 @@ func recover() interface{} {}
 func copy(a, b []int) {}
 `
 	expected := Issues{
-		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 2, Col: 5, Message: "variable iota has same name as predeclared identifier"},
-		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 3, Col: 6, Message: "function recover has same name as predeclared identifier"},
-		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 4, Col: 6, Message: "function copy has same name as predeclared identifier"},
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 2, Col: 5, Message: `variable "iota" has same name as predeclared identifier`},
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 3, Col: 6, Message: `function "recover" has same name as predeclared identifier`},
+		{Linter: "predeclared", Severity: "warning", Path: "test.go", Line: 4, Col: 6, Message: `function "copy" has same name as predeclared identifier`},
 	}
 	ExpectIssues(t, "predeclared", source, expected)
 }


### PR DESCRIPTION
The predeclared command checks for code that shadows Go's predeclared
identifiers.

godoc: https://godoc.org/github.com/nishanths/predeclared
source: https://github.com/nishanths/predeclared

The list of predeclared identifiers is in [the spec](https://golang.org/ref/spec#Predeclared_identifiers).

See related issue #417 for more details.