### PR TITLE
Replace testify with gotestyourself/assert

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestLinterConfigUnmarshalJSON(t *testing.T) {
@@ -17,9 +17,9 @@ func TestLinterConfigUnmarshalJSON(t *testing.T) {
 	}`
 	var config StringOrLinterConfig
 	err := json.Unmarshal([]byte(source), &config)
-	require.NoError(t, err)
-	assert.Equal(t, "/bin/custom", config.Command)
-	assert.Equal(t, functionName(partitionPathsAsDirectories), functionName(config.PartitionStrategy))
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("/bin/custom", config.Command))
+	assert.Check(t, is.Equal(functionName(partitionPathsAsDirectories), functionName(config.PartitionStrategy)))
 }
 
 func TestFindDefaultConfigFile(t *testing.T) {
@@ -73,10 +73,10 @@ func TestFindDefaultConfigFile(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		require.NoError(t, os.Chdir(testcase.dir))
+		assert.NilError(t, os.Chdir(testcase.dir))
 		configFile, found, err := findDefaultConfigFile()
-		assert.Equal(t, testcase.expected, configFile)
-		assert.Equal(t, testcase.found, found)
-		assert.NoError(t, err)
+		assert.Check(t, is.Equal(testcase.expected, configFile))
+		assert.Check(t, is.Equal(testcase.found, found))
+		assert.Check(t, is.NilError(err))
 	}
 }

--- a/directives_test.go
+++ b/directives_test.go
@@ -3,7 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestIgnoreRangeMatch(t *testing.T) {
@@ -37,6 +38,6 @@ func TestIgnoreRangeMatch(t *testing.T) {
 
 	for _, testcase := range testcases {
 		ir := ignoredRange{col: 20, start: 5, end: 20, linters: testcase.linters}
-		assert.Equal(t, testcase.expected, ir.matches(&testcase.issue), testcase.doc)
+		assert.Check(t, is.Equal(testcase.expected, ir.matches(&testcase.issue)), testcase.doc)
 	}
 }

--- a/execute_test.go
+++ b/execute_test.go
@@ -3,7 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestLinterStateCommand(t *testing.T) {
@@ -46,13 +47,13 @@ func TestLinterStateCommand(t *testing.T) {
 			expected: `structcheck -t`,
 		},
 		{
-			linter: "unparam",
-			vars: varsDefault,
+			linter:   "unparam",
+			vars:     varsDefault,
 			expected: `unparam -tests=false`,
 		},
 		{
-			linter: "unparam",
-			vars: varsWithTest,
+			linter:   "unparam",
+			vars:     varsWithTest,
 			expected: `unparam `,
 		},
 	}
@@ -62,6 +63,6 @@ func TestLinterStateCommand(t *testing.T) {
 			Linter: getLinterByName(testcase.linter, LinterConfig{}),
 			vars:   testcase.vars,
 		}
-		assert.Equal(t, testcase.expected, ls.command())
+		assert.Check(t, is.Equal(testcase.expected, ls.command()))
 	}
 }

--- a/issue.go
+++ b/issue.go
@@ -109,10 +109,12 @@ func (i *Issue) String() string {
 	return buf.String()
 }
 
+
 type sortedIssues struct {
 	issues []*Issue
 	order  []string
 }
+
 
 func (s *sortedIssues) Len() int      { return len(s.issues) }
 func (s *sortedIssues) Swap(i, j int) { s.issues[i], s.issues[j] = s.issues[j], s.issues[i] }

--- a/issue_test.go
+++ b/issue_test.go
@@ -4,8 +4,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestSortedIssues(t *testing.T) {
@@ -23,10 +24,10 @@ func TestSortedIssues(t *testing.T) {
 	expected := []*Issue{
 		{Path: newIssuePath("", "a.go"), Line: 1, Col: 4},
 		{Path: newIssuePath("", "a.go"), Line: 3, Col: 2},
-		{Path: newIssuePath( "", "b.go"), Line: 1, Col: 3},
-		{Path: newIssuePath( "", "b.go"), Line: 5, Col: 1},
+		{Path: newIssuePath("", "b.go"), Line: 1, Col: 3},
+		{Path: newIssuePath("", "b.go"), Line: 5, Col: 1},
 	}
-	require.Equal(t, expected, actual)
+	assert.Assert(t, is.Compare(expected, actual, cmpIssue))
 }
 
 func TestCompareOrderWithMessage(t *testing.T) {
@@ -34,6 +35,8 @@ func TestCompareOrderWithMessage(t *testing.T) {
 	issueM := Issue{Path: newIssuePath("", "file.go"), Message: "message"}
 	issueU := Issue{Path: newIssuePath("", "file.go"), Message: "unknown"}
 
-	assert.True(t, CompareIssue(issueM, issueU, order))
-	assert.False(t, CompareIssue(issueU, issueM, order))
+	assert.Check(t, CompareIssue(issueM, issueU, order))
+	assert.Check(t, !CompareIssue(issueU, issueM, order))
 }
+
+var cmpIssue = cmp.AllowUnexported(Issue{}, IssuePath{})

--- a/linters_test.go
+++ b/linters_test.go
@@ -5,8 +5,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestNewLinterWithCustomLinter(t *testing.T) {
@@ -15,11 +15,11 @@ func TestNewLinterWithCustomLinter(t *testing.T) {
 		Pattern: "path",
 	}
 	linter, err := NewLinter("thename", config)
-	require.NoError(t, err)
-	assert.Equal(t, functionName(partitionPathsAsDirectories), functionName(linter.LinterConfig.PartitionStrategy))
-	assert.Equal(t, "(?m:path)", linter.regex.String())
-	assert.Equal(t, "thename", linter.Name)
-	assert.Equal(t, config.Command, linter.Command)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(functionName(partitionPathsAsDirectories), functionName(linter.LinterConfig.PartitionStrategy)))
+	assert.Check(t, is.Equal("(?m:path)", linter.regex.String()))
+	assert.Check(t, is.Equal("thename", linter.Name))
+	assert.Check(t, is.Equal(config.Command, linter.Command))
 }
 
 func TestGetLinterByName(t *testing.T) {
@@ -31,11 +31,11 @@ func TestGetLinterByName(t *testing.T) {
 		IsFast:            true,
 	}
 	overrideConfig := getLinterByName(config.Command, config)
-	assert.Equal(t, config.Command, overrideConfig.Command)
-	assert.Equal(t, config.Pattern, overrideConfig.Pattern)
-	assert.Equal(t, config.InstallFrom, overrideConfig.InstallFrom)
-	assert.Equal(t, functionName(config.PartitionStrategy), functionName(overrideConfig.PartitionStrategy))
-	assert.Equal(t, config.IsFast, overrideConfig.IsFast)
+	assert.Check(t, is.Equal(config.Command, overrideConfig.Command))
+	assert.Check(t, is.Equal(config.Pattern, overrideConfig.Pattern))
+	assert.Check(t, is.Equal(config.InstallFrom, overrideConfig.InstallFrom))
+	assert.Check(t, is.Equal(functionName(config.PartitionStrategy), functionName(overrideConfig.PartitionStrategy)))
+	assert.Check(t, is.Equal(config.IsFast, overrideConfig.IsFast))
 }
 
 func TestValidateLinters(t *testing.T) {
@@ -47,13 +47,13 @@ func TestValidateLinters(t *testing.T) {
 	}
 
 	err := validateLinters(lintersFromConfig(config), config)
-	require.Error(t, err, "expected unknown linter error for _dummylinter_")
+	assert.Assert(t, is.Error(err, "unknown linters: _dummylinter_"))
 
 	config = &Config{
 		Enable: defaultEnabled(),
 	}
 	err = validateLinters(lintersFromConfig(config), config)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 }
 
 func functionName(i interface{}) string {

--- a/partition_test.go
+++ b/partition_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/env"
 )
 
 func TestPartitionToMaxSize(t *testing.T) {
@@ -20,12 +21,12 @@ func TestPartitionToMaxSize(t *testing.T) {
 		append(cmdArgs, "three"),
 		append(cmdArgs, "four"),
 	}
-	assert.Equal(t, expected, parts)
+	assert.Check(t, is.Compare(expected, parts))
 }
 
 func TestPartitionToPackageFileGlobs(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test-expand-paths")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
@@ -39,12 +40,12 @@ func TestPartitionToPackageFileGlobs(t *testing.T) {
 	}
 
 	parts, err := partitionPathsAsFilesGroupedByPackage(cmdArgs, paths)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	expected := [][]string{
 		append(cmdArgs, packagePaths(paths[0], "file.go", "other.go")...),
 		append(cmdArgs, packagePaths(paths[1], "file.go", "other.go")...),
 	}
-	assert.Equal(t, expected, parts)
+	assert.Check(t, is.Compare(expected, parts))
 }
 
 func packagePaths(dir string, filenames ...string) []string {
@@ -57,45 +58,39 @@ func packagePaths(dir string, filenames ...string) []string {
 
 func TestPartitionToPackageFileGlobsNoFiles(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test-expand-paths")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
 	parts, err := partitionPathsAsFilesGroupedByPackage(cmdArgs, paths)
-	require.NoError(t, err)
-	assert.Len(t, parts, 0)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(parts, 0))
 }
 
 func TestPartitionToMaxArgSizeWithFileGlobsNoFiles(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test-expand-paths")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	cmdArgs := []string{"/usr/bin/foo", "-c"}
 	paths := []string{filepath.Join(tmpdir, "one"), filepath.Join(tmpdir, "two")}
 	parts, err := partitionPathsAsFiles(cmdArgs, paths)
-	require.NoError(t, err)
-	assert.Len(t, parts, 0)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(parts, 0))
 }
 
 func TestPathsToPackagePaths(t *testing.T) {
 	root := "/fake/root"
-	defer fakeGoPath(t, root)()
+	defer env.Patch(t, "GOPATH", root)()
 
 	packagePaths, err := pathsToPackagePaths([]string{
 		filepath.Join(root, "src", "example.com", "foo"),
 		"./relative/package",
 	})
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	expected := []string{"example.com/foo", "./relative/package"}
-	assert.Equal(t, expected, packagePaths)
-}
-
-func fakeGoPath(t *testing.T, path string) func() {
-	oldpath := os.Getenv("GOPATH")
-	require.NoError(t, os.Setenv("GOPATH", path))
-	return func() { require.NoError(t, os.Setenv("GOPATH", oldpath)) }
+	assert.Check(t, is.Compare(expected, packagePaths))
 }
 
 func TestPartitionPathsByDirectory(t *testing.T) {
@@ -103,12 +98,12 @@ func TestPartitionPathsByDirectory(t *testing.T) {
 	paths := []string{"one", "two", "three"}
 
 	parts, err := partitionPathsByDirectory(cmdArgs, paths)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	expected := [][]string{
 		append(cmdArgs, "one"),
 		append(cmdArgs, "two"),
 		append(cmdArgs, "three"),
 	}
-	assert.Equal(t, expected, parts)
+	assert.Check(t, is.Compare(expected, parts))
 
 }

--- a/regressiontests/gas_test.go
+++ b/regressiontests/gas_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGas(t *testing.T) {
@@ -20,7 +21,7 @@ func TestGas(t *testing.T) {
 		{Linter: "gas", Severity: "warning", Path: "sub/file.go", Line: 3, Col: 0, Message: "Errors unhandled.,LOW,HIGH"},
 	}
 	actual := RunLinter(t, "gas", dir.Path())
-	assert.Equal(t, expected, actual)
+	assert.Check(t, is.Compare(expected, actual))
 }
 
 func gasFileErrorUnhandled(pkg string) string {

--- a/regressiontests/gotype_test.go
+++ b/regressiontests/gotype_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGoType(t *testing.T) {
@@ -24,7 +25,7 @@ func TestGoType(t *testing.T) {
 		{Linter: "gotype", Severity: "error", Path: "sub/file.go", Line: 4, Col: 6, Message: "foo declared but not used"},
 	}
 	actual := RunLinter(t, "gotype", dir.Path(), "--skip=excluded")
-	assert.Equal(t, expected, actual)
+	assert.Check(t, is.Compare(expected, actual))
 }
 
 func TestGoTypeWithMultiPackageDirectoryTest(t *testing.T) {
@@ -41,9 +42,8 @@ func TestGoTypeWithMultiPackageDirectoryTest(t *testing.T) {
 	}
 	actual := RunLinter(t, "gotype", dir.Path())
 	actual = append(actual, RunLinter(t, "gotypex", dir.Path())...)
-	assert.Equal(t, expected, actual)
+	assert.Check(t, is.Compare(expected, actual))
 }
-
 
 func goTypeFile(pkg string) string {
 	return fmt.Sprintf(`package %s

--- a/regressiontests/support.go
+++ b/regressiontests/support.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type Issue struct {
@@ -40,15 +40,15 @@ type Issues []Issue
 func ExpectIssues(t *testing.T, linter string, source string, expected Issues, extraFlags ...string) {
 	// Write source to temporary directory.
 	dir, err := ioutil.TempDir(".", "gometalinter-")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
 
 	testFile := filepath.Join(dir, "test.go")
 	err = ioutil.WriteFile(testFile, []byte(source), 0644)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	actual := RunLinter(t, linter, dir, extraFlags...)
-	assert.Equal(t, expected, actual)
+	assert.Check(t, is.Compare(expected, actual))
 }
 
 // RunLinter runs the gometalinter as a binary against the files at path and
@@ -73,7 +73,7 @@ func RunLinter(t *testing.T, linter string, path string, extraFlags ...string) I
 
 	var actual Issues
 	err := json.Unmarshal(output, &actual)
-	if !assert.NoError(t, err) {
+	if !assert.Check(t, is.NilError(err)) {
 		fmt.Printf("Stderr: %s\n", errBuffer)
 		fmt.Printf("Output: %s\n", output)
 		return nil
@@ -85,7 +85,7 @@ func buildBinary(t *testing.T) (string, func()) {
 	tmpdir := fs.NewDir(t, "regression-test-binary")
 	path := tmpdir.Join("gometalinter")
 	cmd := exec.Command("go", "build", "-o", path, "..")
-	require.NoError(t, cmd.Run())
+	assert.NilError(t, cmd.Run())
 	return path, tmpdir.Remove
 }
 

--- a/regressiontests/vet_test.go
+++ b/regressiontests/vet_test.go
@@ -3,8 +3,9 @@ package regressiontests
 import (
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestVet(t *testing.T) {
@@ -27,7 +28,7 @@ func TestVet(t *testing.T) {
 		{Linter: "vet", Severity: "error", Path: "sub/file.go", Line: 7, Col: 0, Message: "unreachable code"},
 	}
 	actual := RunLinter(t, "vet", dir.Path(), "--skip=excluded")
-	assert.Equal(t, expected, actual)
+	assert.Check(t, is.Compare(expected, actual))
 }
 
 func vetFile(pkg string) string {


### PR DESCRIPTION
I've been a user of `testify` for a while, however I've noticed it is not really maintained anymore and there are still a [lot of things I'd like to change](https://github.com/test-go/testify/issues/13).

`gotestyourself/fs` is already in use in the test suite, so I was wondering if you would accept using the assertions as well. The interface is similar to testify, but it does try to fix some of the problems with the old interface. 

Comments on the interface are definitely welcome.