### PR TITLE
Always ignore vendor directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,10 @@ ones you want:
 
 ### How do I make `gometalinter` work with Go 1.5 vendoring?
 
-`gometalinter` has a `--vendor` flag that just sets `GO15VENDOREXPERIMENT=1`, however the
-underlying tools must support it. Ensure that all of the linters are up to date and built with Go 1.5
-(`gometalinter --install --force`) then run `gometalinter --vendor .`. That should be it.
+`gometalinter` always sets `GO15VENDOREXPERIMENT=1` and ignores `vendor`
+directories, however the underlying tools must support it. Ensure that all
+of the linters are up to date and built with at least Go 1.5 (`gometalinter
+--install --force`) then run `gometalinter .`. That should be it.
 
 ### Why does `gometalinter --install` install a fork of gocyclo?
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,6 @@ type Config struct { // nolint: maligned
 	Exclude         []string
 	Include         []string
 	Skip            []string
-	Vendor          bool
 	Cyclo           int
 	LineLength      int
 	MisspellLocale  string


### PR DESCRIPTION
This makes us do what --vendor optionally did. There is now no way
enable the previous behaviour. I considered adding something like
--lint-vendor, but that does not seem useful.

Fixes #452.

Thanks again!