### PR TITLE
Install only enabled linters

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,8 @@ type Config struct { // nolint: maligned
 	Enable  []string
 	Disable []string
 
+	Installable []string
+
 	// A map of linter name to message that is displayed. This is useful when linters display text
 	// that is useful only in isolation, such as errcheck which just reports the construct.
 	MessageOverride map[string]string

--- a/linters.go
+++ b/linters.go
@@ -151,7 +151,7 @@ func retrieveLinterConfigs(names []string) map[string]LinterConfig {
 }
 
 func installLinters() {
-	linters := retrieveLinterConfigs(config.Enable)
+	linters := retrieveLinterConfigs(config.Installable)
 	names := make([]string, 0, len(linters))
 	targets := make([]string, 0, len(linters))
 	for name, config := range linters {

--- a/linters.go
+++ b/linters.go
@@ -140,10 +140,21 @@ func installLintersIndividually(targets []string) {
 	}
 }
 
+func retrieveLinterConfigs(names []string) map[string]LinterConfig {
+	configs := make(map[string]LinterConfig)
+	for _, v := range names {
+		if config, ok := defaultLinters[v]; ok {
+			configs[v] = config
+		}
+	}
+	return configs
+}
+
 func installLinters() {
-	names := make([]string, 0, len(defaultLinters))
-	targets := make([]string, 0, len(defaultLinters))
-	for name, config := range defaultLinters {
+	linters := retrieveLinterConfigs(config.Enable)
+	names := make([]string, 0, len(linters))
+	targets := make([]string, 0, len(linters))
+	for name, config := range linters {
 		if config.InstallFrom == "" {
 			continue
 		}


### PR DESCRIPTION
The introduces the idea of only installing enabled linters. This
is useful when you know that you're only going to ever run a certain
linter. It reduces the number of potential moving parts along with
the added advantage of hastening the install process. This especially
useful for a CI workflow.

Running the following shows the changes:

```
gometalinter --disable-all --enable=goimports --install
```