### PR TITLE
Fix: gometalinter can't work on multi-GOPATH

### DIFF
--- a/partition.go
+++ b/partition.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -146,12 +147,23 @@ func packageNameFromPath(path string) (string, error) {
 	}
 	for _, gopath := range getGoPathList() {
 		rel, err := filepath.Rel(filepath.Join(gopath, "src"), path)
-		if err != nil {
+		if err != nil || rel[0] == '.' {
 			continue
 		}
 		return rel, nil
 	}
-	return "", fmt.Errorf("%s not in GOPATH", path)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("Can't get package name from path %s, err: %v", path, err)
+	}
+
+	rel, err := filepath.Rel(wd, path)
+	if err != nil {
+		return "", fmt.Errorf("Can't get package name from path %s, err: %v", path, err)
+	}
+
+	return rel, nil
 }
 
 func partitionPathsByDirectory(cmdArgs []string, paths []string) ([][]string, error) {

--- a/partition_test.go
+++ b/partition_test.go
@@ -80,15 +80,34 @@ func TestPartitionToMaxArgSizeWithFileGlobsNoFiles(t *testing.T) {
 }
 
 func TestPathsToPackagePaths(t *testing.T) {
-	root := "/fake/root"
-	defer fakeGoPath(t, root)()
+	root1 := "/fake/root1"
+	root2 := "/fake/root2"
+	root3 := "/fake/root3"
+	gopath := root1 + ":" + root2 + ":" + root3
+	defer fakeGoPath(t, gopath)()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	outsidePath := "/fake/outside/example4.com/foo4"
+	outsidePackage, _ := filepath.Rel(wd, outsidePath)
 
 	packagePaths, err := pathsToPackagePaths([]string{
-		filepath.Join(root, "src", "example.com", "foo"),
+		filepath.Join(root1, "src", "example1.com", "foo1"),
+		filepath.Join(root2, "src", "example2.com", "foo2"),
+		filepath.Join(root3, "src", "example3.com", "foo3"),
+		outsidePath,
 		"./relative/package",
 	})
 	require.NoError(t, err)
-	expected := []string{"example.com/foo", "./relative/package"}
+
+	expected := []string{
+		"example1.com/foo1",
+		"example2.com/foo2",
+		"example3.com/foo3",
+		outsidePackage,
+		"./relative/package",
+	}
 	assert.Equal(t, expected, packagePaths)
 }
 


### PR DESCRIPTION
The function call packageNameFromPath(path) will return a wrong result
when `path` is not in the first GOPATH. It just returns the `relpath` which
relative to the first GOPATH, but the source code is not in there in fact.

This commit will try next GOPATH when got a wrong `relpath`,
and try os.Getwd() when all GOPATH failed.

This should close issue #478.