### PR TITLE
Remove govet from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,12 +44,6 @@ builds:
     env: *env
     main: ./_linters/src/github.com/client9/misspell/cmd/misspell
 
-  - binary: govet
-    goos: *goos
-    goarch: *goarch
-    env: *env
-    main: ./_linters/src/github.com/dnephin/govet
-
   - binary: gas
     goos: *goos
     goarch: *goarch


### PR DESCRIPTION
The source was removed from `_linters` but it's still  referenced in the goreleaser config