### PR TITLE
Update gochecknoglobals

### DIFF
--- a/_linters/src/4d63.com/gochecknoglobals/main.go
+++ b/_linters/src/4d63.com/gochecknoglobals/main.go
@@ -7,9 +7,11 @@ import (
 )
 
 func main() {
-	flagPrintHelp := flag.Bool("help", false, "")
+	flagPrintHelp := flag.Bool("h", false, "Print help")
+	flagIncludeTests := flag.Bool("t", false, "Include tests")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: gochecknoglobals [path] [path] ...\n")
+		fmt.Fprintf(os.Stderr, "Usage: gochecknoglobals [-t] [path] [path] ...\n")
+		flag.PrintDefaults()
 	}
 	flag.Parse()
 
@@ -17,6 +19,8 @@ func main() {
 		flag.Usage()
 		return
 	}
+
+	includeTests := *flagIncludeTests
 
 	paths := flag.Args()
 	if len(paths) == 0 {
@@ -26,7 +30,7 @@ func main() {
 	exitWithError := false
 
 	for _, path := range paths {
-		messages, err := checkNoGlobals(path)
+		messages, err := checkNoGlobals(path, includeTests)
 		for _, message := range messages {
 			fmt.Fprintf(os.Stdout, "%s\n", message)
 			exitWithError = true

--- a/_linters/src/manifest
+++ b/_linters/src/manifest
@@ -5,7 +5,7 @@
 			"importpath": "4d63.com/gochecknoglobals",
 			"repository": "https://github.com/leighmcculloch/gochecknoglobals",
 			"vcs": "git",
-			"revision": "9a66a4a931c82990a7eb42e057408ac5f2bb6bee",
+			"revision": "5090db600a84f7a401cb031f4e8e2e420b0e1ecd",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
What
===
Update `gochecknoglobals`.

Why
===
As of leighmcculloch/gochecknoglobals#3 `gochecknoglobals` now handles package-level errors better by ignoring them if they have the `err` or `Err` prefix.

Note
===
The update was performed by running `cd _linters && gvt update 4d63.com/gochecknoglobals`
