### PR TITLE
Pass error out of goroutine via channel

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -155,15 +155,14 @@ func executeLinter(id int, state *linterState, args []string) error {
 		return fmt.Errorf("failed to execute linter %s: %s", command, err)
 	}
 
-	done := make(chan bool)
+	done := make(chan error)
 	go func() {
-		err = cmd.Wait()
-		done <- true
+		done <- cmd.Wait()
 	}()
 
 	// Wait for process to complete or deadline to expire.
 	select {
-	case <-done:
+	case err = <-done:
 
 	case <-state.deadline:
 		err = fmt.Errorf("deadline exceeded by linter %s (try increasing --deadline)",


### PR DESCRIPTION
This avoids a data race on `err` between the inner goroutine
and the deadline arm below.