### PR TITLE
linters: fix: multiline gosec warnings not shown in gometalinter result

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -233,7 +233,7 @@ var defaultLinters = map[string]LinterConfig{
 	},
 	"gosec": {
 		Command:           `gosec -fmt=csv`,
-		Pattern:           `^(?P<path>.*?\.go),(?P<line>\d+),(?P<message>[^,]+,[^,]+,[^,]+)`,
+		Pattern:           `^(?P<path>.*?\.go),(?P<line>\d+)(-\d+)?,(?P<message>[^,]+,[^,]+,[^,]+)`,
 		InstallFrom:       "github.com/securego/gosec/cmd/gosec",
 		PartitionStrategy: partitionPathsAsPackages,
 		defaultEnabled:    true,


### PR DESCRIPTION
The gosec linter is printing a range expression like `1200-1204` for the
line number in some cases.
The gosec output in csv looks like:

```
/home/fho/git/test/example.go,1200-1204,SQL string formatting,MEDIUM,HIGH,"fmt.Sprintf(`
			SELECT
				%s,
			FROM test
		)"
```

The gometalinter line pattern was only expecting one or more digits as line
number.
This caused that some warnings did not match the pattern and did not
show up in the gometalinter results.

The Gosec pattern is changed to parse the first number as line number
and ignore an eventual following `-<NUMBER>` expression.
Gometalinter only supports to work with a single number for lines.