### PR TITLE
Release freebsd/openbsd/netbsd and arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,9 +26,13 @@ builds:
       - darwin
       - windows
       - linux
+      - freebsd
+      - openbsd
+      - netbsd
     goarch: &goarch
       - amd64
       - i386
+      - arm64
     env:
       - CGO_ENABLED=0
     main: ./


### PR DESCRIPTION
Since goreleaser-produced binaries is now the official way
to use stable gometalinter, it makes sense to cover more
GOOS/GOARCH combinations.

Update #552

Signed-off-by: Dmitry Vyukov <dvyukov@google.com>