### PR TITLE
resolvePaths: evaluate symlinks before recursing

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,6 +324,12 @@ func resolvePaths(paths, skip []string) []string {
 	for _, path := range paths {
 		if strings.HasSuffix(path, "/...") {
 			root := filepath.Dir(path)
+			// if root is a symlink evaluate it once, but don't resolve symlinks when recursing
+			root, err := filepath.EvalSymlinks(root)
+			if err != nil {
+				warning("Unable to resolve symlinks: %s %s", root, err)
+				continue
+			}
 			_ = filepath.Walk(root, func(p string, i os.FileInfo, err error) error {
 				if err != nil {
 					warning("invalid path %q: %s", p, err)


### PR DESCRIPTION
If the root path is a symlink, evaluate it once then
recurse.  We don't want to evaluate symlinks while walking
because that can lead to loops.

The root path might be a symlink in order for developers
to place a project under GOPATH without modifying GOPATH.

This is not ideal because it rewrites the path which can confuse IDEs
and automated error parsing, but this patch at least allows us to
traverse the directories.

Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>