### PR TITLE
Update gochecknoglobals to abbdf6ec0afbf03522985f899c67ead98818854d

### DIFF
--- a/_linters/src/4d63.com/gochecknoglobals/check_no_globals.go
+++ b/_linters/src/4d63.com/gochecknoglobals/check_no_globals.go
@@ -68,13 +68,13 @@ func checkNoGlobals(rootPath string, includeTests bool) ([]string, error) {
 				continue
 			}
 			filename := fset.Position(genDecl.TokPos).Filename
-			line := fset.Position(genDecl.TokPos).Line
 			for _, spec := range genDecl.Specs {
 				valueSpec := spec.(*ast.ValueSpec)
 				for _, vn := range valueSpec.Names {
 					if isWhitelisted(vn) {
 						continue
 					}
+					line := fset.Position(vn.Pos()).Line
 					message := fmt.Sprintf("%s:%d %s is a global variable", filename, line, vn.Name)
 					messages = append(messages, message)
 				}

--- a/_linters/src/manifest
+++ b/_linters/src/manifest
@@ -5,7 +5,7 @@
 			"importpath": "4d63.com/gochecknoglobals",
 			"repository": "https://github.com/leighmcculloch/gochecknoglobals",
 			"vcs": "git",
-			"revision": "5090db600a84f7a401cb031f4e8e2e420b0e1ecd",
+			"revision": "abbdf6ec0afbf03522985f899c67ead98818854d",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This fixes the line number for variables inside a 'var' group.
See https://github.com/leighmcculloch/gochecknoglobals/pull/9