### PR TITLE
Pass -t to gochecknoglobals

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -248,7 +248,7 @@ var defaultLinters = map[string]LinterConfig{
 		IsFast:            true,
 	},
 	"gochecknoglobals": {
-		Command:           `gochecknoglobals`,
+		Command:           `gochecknoglobals {tests=-t}`,
 		Pattern:           `^(?P<path>.*?\.go):(?P<line>\d+) (?P<message>.*)`,
 		InstallFrom:       "4d63.com/gochecknoglobals",
 		PartitionStrategy: partitionPathsAsDirectories,


### PR DESCRIPTION
gochecknoglobals was updated to `abbdf6ec0afbf03522985f899c67ead98818854d`
which also included `9d4b45f358725d2a99ed997af46cc87def6038ec` where
gochecknoglobals does not include tests by default any more and requires
a -t flag.

Pass -t to gochecknoglobals if linting tests is requested.